### PR TITLE
Fix CSV time output SP-1811

### DIFF
--- a/DistFiles/releaseNotes.md
+++ b/DistFiles/releaseNotes.md
@@ -1,3 +1,7 @@
+## Version 3.1
+When doing an IMDI export,you can now select a "metadata only" option.
+When exporting a transcription as CSV, the time format now conforms to the ISO 8601 standard (hh:mm:ss.ff instead of hh:mm:ss:ff).
+
 #What's New in Version 3
 
 ##IMDI Archiving

--- a/src/SayMore/Transcription/Model/Exporters/CSVTranscriptionExporter.cs
+++ b/src/SayMore/Transcription/Model/Exporters/CSVTranscriptionExporter.cs
@@ -9,7 +9,7 @@ namespace SayMore.Transcription.Model.Exporters
 	{
 		public static void Export(string outputFilePath, TierCollection tiers)
 		{
-			const string ktimeFormat = "hh\\:mm\\:ss\\:ff";
+			const string ktimeFormat = "hh\\:mm\\:ss\\.ff"; //ISO 8601 and what ELAN import expects
 			using (var stream = File.CreateText(outputFilePath))
 			{
 				int count = tiers.GetTimeTier().Segments.Count;


### PR DESCRIPTION
Milliseconds should be preceeded by a decimal point, not a colon.