### PR TITLE
st378 Avoid setting Actor language to undefined.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 obj/*
 output/*
+.vs*
 *.suo
 *.user
 _ReSharper*
@@ -65,7 +66,7 @@ Thumbs.db
 src/AutoSegmenter/obj/x86/Debug/DesignTimeResolveAssemblyReferencesInput.cache
 lib/dotnet/L10NSharp*
 lib/dotnet/SilUtils.dll
-lib/dotnet/SIL.Archiving.*
+lib/dotnet/SIL.*
 lib/dotnet/icu*
 lib/dotnet/Interop*
 lib/dotnet/Ionic*
@@ -82,5 +83,5 @@ packages/Analytics*
 lib/dotnet/SIL.*.dll
 lib/dotnet/SIL.*.pdb
 .nuget/NuGet.exe
-build/SIL.BuildTasks.dll
+build/SIL.BuildTasks.*
 lib/dotnet/NAudio.dll

--- a/src/SayMore/Model/ArchivingHelper.cs
+++ b/src/SayMore/Model/ArchivingHelper.cs
@@ -170,7 +170,7 @@ namespace SayMore.Model
 			// session situation
 			stringVal = saymoreSession.MetaDataFile.GetStringValue("situation", null);
 			if (!string.IsNullOrEmpty(stringVal))
-				imdiSession.AddKeyValuePair("Situation", stringVal);
+				imdiSession.AddContentKeyValuePair("Situation", stringVal);
 
 			imdiSession.Genre = GetFieldValue(sessionFile, "genre");
 			imdiSession.SubGenre = GetFieldValue(sessionFile, "additional_Sub-Genre");
@@ -183,7 +183,7 @@ namespace SayMore.Model
 
 			// custom session fields
 			foreach (var item in saymoreSession.MetaDataFile.GetCustomFields())
-				imdiSession.AddKeyValuePair(item.FieldId, item.ValueAsString);
+				imdiSession.AddContentKeyValuePair(item.FieldId, item.ValueAsString);
 
 			// actors
 			var actors = new ArchivingActorCollection();

--- a/src/SayMore/Model/ArchivingHelper.cs
+++ b/src/SayMore/Model/ArchivingHelper.cs
@@ -196,15 +196,19 @@ namespace SayMore.Model
 				var actor = InitializeActor(model, person, sessionDateTime);
 
 				// do this to get the ISO3 codes for the languages because they are not in saymore
-				actor.PrimaryLanguage = GetOneLanguage(person.MetaDataFile.GetStringValue("primaryLanguage", null));
-				actor.MotherTongueLanguage = GetOneLanguage(person.MetaDataFile.GetStringValue("mothersLanguage", null));
+				var language = GetOneLanguage(person.MetaDataFile.GetStringValue("primaryLanguage", null));
+				if (language != null) actor.PrimaryLanguage = language;
+				language = GetOneLanguage(person.MetaDataFile.GetStringValue("mothersLanguage", null));
+				if (language != null) actor.MotherTongueLanguage = language;
 
 				// otherLanguage0 - otherLanguage3
 				for (var i = 0; i < 4; i++)
 				{
 					var languageKey = person.MetaDataFile.GetStringValue("otherLanguage" + i, null);
 					if (string.IsNullOrEmpty(languageKey)) continue;
-					actor.Iso3Languages.Add(GetOneLanguage(languageKey));
+					language = GetOneLanguage(languageKey);
+					if (language == null) continue;
+					actor.Iso3Languages.Add(language);
 				}
 
 				// custom person fields

--- a/src/SayMore/SayMore.csproj
+++ b/src/SayMore/SayMore.csproj
@@ -102,6 +102,9 @@
     <Reference Include="SIL.Core">
       <HintPath>..\..\lib\dotnet\SIL.Core.dll</HintPath>
     </Reference>
+    <Reference Include="SIL.Core.Desktop">
+      <HintPath>..\..\lib\dotnet\SIL.Core.Desktop.dll</HintPath>
+    </Reference>
     <Reference Include="SIL.Media">
       <HintPath>..\..\lib\dotnet\SIL.Media.dll</HintPath>
     </Reference>

--- a/src/SayMoreTests/SayMoreTests.csproj
+++ b/src/SayMoreTests/SayMoreTests.csproj
@@ -82,6 +82,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\dotnet\SIL.Core.dll</HintPath>
     </Reference>
+    <Reference Include="SIL.Core.Desktop">
+      <HintPath>..\..\lib\dotnet\SIL.Core.Desktop.dll</HintPath>
+    </Reference>
     <Reference Include="SIL.Media">
       <HintPath>..\..\lib\dotnet\SIL.Media.dll</HintPath>
     </Reference>
@@ -204,6 +207,9 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="Resources\longerSound.wav" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/SayMoreTests/model/SessionArchivingTests.cs
+++ b/src/SayMoreTests/model/SessionArchivingTests.cs
@@ -227,7 +227,7 @@ namespace SayMoreTests.Utilities
 		}
 
 		[Test]
-		public void GetOneLanguage_DefinedIsoTest()
+		public void GetOneLanguage_DefinedIso_ReturnsCodeAndName()
 		{
 			var returnValue = ArchivingHelper.GetOneLanguage("eng");
 			Assert.AreEqual("eng", returnValue.Iso3Code);
@@ -236,7 +236,7 @@ namespace SayMoreTests.Utilities
 		}
 
 		[Test]
-		public void GetOneLanguage_DefinedNameTest()
+		public void GetOneLanguage_DefinedName_ReturnsCodeAndName()
 		{
 			var returnValue = ArchivingHelper.GetOneLanguage("English");
 			Assert.AreEqual("eng", returnValue.Iso3Code);
@@ -246,16 +246,23 @@ namespace SayMoreTests.Utilities
 
 		[Test]
 		[Category("SkipOnTeamCity")]
-		public void GetOneLanguage_UndefinedIsoTest()
+		public void GetOneLanguage_UndefinedIso_ReturnsNull()
 		{
+			ArchivingHelper._defaultLanguage = null;
 			var returnValue = ArchivingHelper.GetOneLanguage("tru");
-			Assert.AreEqual("tru", returnValue.Iso3Code);
-			Assert.AreEqual("Turoyo", returnValue.LanguageName);
-			Assert.AreEqual("Turoyo", returnValue.EnglishName);
+			Assert.IsNull(returnValue);
 		}
 
 		[Test]
-		public void GetOneLanguage_DefaultIsoTest()
+		public void GetOneLanguage_UnDefinedName_ReturnsNull()
+		{
+			ArchivingHelper._defaultLanguage = null;
+			var returnValue = ArchivingHelper.GetOneLanguage("Turoyo");
+			Assert.IsNull(returnValue);
+		}
+
+		[Test]
+		public void GetOneLanguage_DefaultIso_ReturnsCodeAndName()
 		{
 			ArchivingHelper._defaultLanguage = new ArchivingLanguage("tru", "Turoyo", "Turoyo");
 			var returnValue = ArchivingHelper.GetOneLanguage("tru");
@@ -265,13 +272,41 @@ namespace SayMoreTests.Utilities
 		}
 
 		[Test]
-		public void GetOneLanguage_DefaultNameTest()
+		public void GetOneLanguage_DefaultName_ReturnsCodeAndName()
 		{
 			ArchivingHelper._defaultLanguage = new ArchivingLanguage("tru", "Turoyo", "Turoyo");
 			var returnValue = ArchivingHelper.GetOneLanguage("Turoyo");
 			Assert.AreEqual("tru", returnValue.Iso3Code);
 			Assert.AreEqual("Turoyo", returnValue.LanguageName);
 			Assert.AreEqual("Turoyo", returnValue.EnglishName);
+		}
+
+		/// <see cref="en.wikipedia.org/wiki/List_of_ISO_639-2_codes"/>
+		[Test]
+		[Category("SkipOnTeamCity")]
+		public void GetOneLanguage_PrivateUseIso_ReturnsNull()
+		{
+			ArchivingHelper._defaultLanguage = null;
+			var returnValue = ArchivingHelper.GetOneLanguage("qaa");
+			Assert.IsNull(returnValue);
+		}
+
+		/// <see cref="en.wikipedia.org/wiki/List_of_ISO_639-2_codes"/>
+		[Test]
+		public void GetOneLanguage_MissingIso_ReturnsNull()
+		{
+			ArchivingHelper._defaultLanguage = null;
+			var returnValue = ArchivingHelper.GetOneLanguage("mis");
+			Assert.IsNull(returnValue);
+		}
+
+		/// <see cref="en.wikipedia.org/wiki/List_of_ISO_639-2_codes"/>
+		[Test]
+		public void GetOneLanguage_UndeterminedIso_ReturnsNull()
+		{
+			ArchivingHelper._defaultLanguage = null;
+			var returnValue = ArchivingHelper.GetOneLanguage("und");
+			Assert.IsNull(returnValue);
 		}
 		#endregion
 	}

--- a/src/SayMoreTests/model/SessionArchivingTests.cs
+++ b/src/SayMoreTests/model/SessionArchivingTests.cs
@@ -202,25 +202,76 @@ namespace SayMoreTests.Utilities
 		[Test]
 		public void InitializeActor_AgeTest()
 		{
-			var model = new Mock<IMDIArchivingDlgViewModel>(MockBehavior.Strict, "SayMore", "ddo", "ddo-session", "whatever", false, null, @"C:\my_imdi_folder");
+			var model = new Mock<IMDIArchivingDlgViewModel>(MockBehavior.Strict, "SayMore", "ddo", "ddo-session", "whatever",
+				false, null, @"C:\my_imdi_folder");
 			var person = new Mock<Person>();
 			person.Setup(p => p.MetaDataFile.GetStringValue("privacyProtection", "false")).Returns("false");
 			person.Setup(p => p.MetaDataFile.GetStringValue("birthYear", string.Empty)).Returns(string.Empty);
 			var actor = ArchivingHelper.InitializeActor(model.Object, person.Object, DateTime.MinValue);
-			Assert.AreEqual("0",actor.Age);
+			Assert.AreEqual("0", actor.Age);
 			model.VerifyAll();
 		}
 
 		[Test]
 		public void InitializeActor_Age68Test()
 		{
-			var model = new Mock<IMDIArchivingDlgViewModel>(MockBehavior.Strict, "SayMore", "ddo", "ddo-session", "whatever", false, null, @"C:\my_imdi_folder");
+			var model = new Mock<IMDIArchivingDlgViewModel>(MockBehavior.Strict, "SayMore", "ddo", "ddo-session", "whatever",
+				false, null, @"C:\my_imdi_folder");
 			var person = new Mock<Person>();
 			person.Setup(p => p.MetaDataFile.GetStringValue("privacyProtection", "false")).Returns("false");
 			person.Setup(p => p.MetaDataFile.GetStringValue("birthYear", string.Empty)).Returns("1950");
-			var actor = ArchivingHelper.InitializeActor(model.Object, person.Object, new DateTime(2018, 1,1));
+			var actor = ArchivingHelper.InitializeActor(model.Object, person.Object, new DateTime(2018, 1, 1));
 			Assert.AreEqual("68", actor.Age);
+			person.VerifyAll();
 			model.VerifyAll();
+		}
+
+		[Test]
+		public void GetOneLanguage_DefinedIsoTest()
+		{
+			var returnValue = ArchivingHelper.GetOneLanguage("eng");
+			Assert.AreEqual("eng", returnValue.Iso3Code);
+			Assert.AreEqual("English", returnValue.LanguageName);
+			Assert.AreEqual("English", returnValue.EnglishName);
+		}
+
+		[Test]
+		public void GetOneLanguage_DefinedNameTest()
+		{
+			var returnValue = ArchivingHelper.GetOneLanguage("English");
+			Assert.AreEqual("eng", returnValue.Iso3Code);
+			Assert.AreEqual("English", returnValue.LanguageName);
+			Assert.AreEqual("English", returnValue.EnglishName);
+		}
+
+		[Test]
+		[Category("SkipOnTeamCity")]
+		public void GetOneLanguage_UndefinedIsoTest()
+		{
+			var returnValue = ArchivingHelper.GetOneLanguage("tru");
+			Assert.AreEqual("tru", returnValue.Iso3Code);
+			Assert.AreEqual("Turoyo", returnValue.LanguageName);
+			Assert.AreEqual("Turoyo", returnValue.EnglishName);
+		}
+
+		[Test]
+		public void GetOneLanguage_DefaultIsoTest()
+		{
+			ArchivingHelper._defaultLanguage = new ArchivingLanguage("tru", "Turoyo", "Turoyo");
+			var returnValue = ArchivingHelper.GetOneLanguage("tru");
+			Assert.AreEqual("tru", returnValue.Iso3Code);
+			Assert.AreEqual("Turoyo", returnValue.LanguageName);
+			Assert.AreEqual("Turoyo", returnValue.EnglishName);
+		}
+
+		[Test]
+		public void GetOneLanguage_DefaultNameTest()
+		{
+			ArchivingHelper._defaultLanguage = new ArchivingLanguage("tru", "Turoyo", "Turoyo");
+			var returnValue = ArchivingHelper.GetOneLanguage("Turoyo");
+			Assert.AreEqual("tru", returnValue.Iso3Code);
+			Assert.AreEqual("Turoyo", returnValue.LanguageName);
+			Assert.AreEqual("Turoyo", returnValue.EnglishName);
 		}
 		#endregion
 	}


### PR DESCRIPTION
When the project is exported the language used by the project is
retained and used if the language is undefined.

This change depends on https://github.com/sillsdev/libpalaso/pull/624
Card: trello.com/c/2daw3H2s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/19)
<!-- Reviewable:end -->
