### PR TITLE
St385- IMDI .meta files are not part of IMDI export

### DIFF
--- a/src/SayMore/Model/ArchivingHelper.cs
+++ b/src/SayMore/Model/ArchivingHelper.cs
@@ -256,6 +256,8 @@ namespace SayMore.Model
 			var files = saymoreSession.GetSessionFilesToArchive(model.GetType());
 			foreach (var file in files)
 			{
+				if (file.EndsWith(Settings.Default.MetadataFileExtension, StringComparison.InvariantCulture))
+					continue;
 				imdiSession.AddFile(CreateArchivingFile(file));
 				var info = saymoreSession.GetComponentFiles().FirstOrDefault(componentFile => componentFile.PathToAnnotatedFile == file);
 				if (info == null || !info.FileType.IsAudioOrVideo)


### PR DESCRIPTION
The information in these files needs to be put into the .imdi file
if it is to be included in the export.

card: https://trello.com/c/A4Z2PJH7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/24)
<!-- Reviewable:end -->
