### PR TITLE
St388 - Update ELAR protocol to OUS

### DIFF
--- a/DistFiles/Archiving/AccessProtocols.json
+++ b/DistFiles/Archiving/AccessProtocols.json
@@ -16,9 +16,8 @@
 	{"label":"No access until specific date","description":"No access until specific date"},
 	{"label":"Restricted access","description":"Restricted access"}]},
 {"protocol":"ELAR","documentation":"elar.html","choices":[
-	{"label":"U","description":"all Users can access"},
-	{"label":"R","description":"Researchers and Community members are allowed access"},
-	{"label":"C","description":"only Community members are allowed access (normally requires application to Depositor)"},
+	{"label":"O","description":"Open to unregistered visitors"},
+	{"label":"U","description":"all ordinary Users can access"},
 	{"label":"S","description":"only Subscribers are allowed access (requires application to Depositor)"}]},
 {"protocol":"REAP","documentation":"reap.html","choices":[
 	{"label":"","description":"<unknown>"},

--- a/DistFiles/Archiving/elar.html
+++ b/DistFiles/Archiving/elar.html
@@ -43,22 +43,17 @@
         <td colspan="3" class="bold space-before">Choices:</td>
       </tr>
       <tr>
-        <td class="fixed">U</td>
+        <td class="fixed">O</td>
         <td>-</td>
-        <td>all Users can access</td>
+        <td>open to unregistered visitors</td>
       </tr>
       <tr>
-        <td class="fixed">&nbsp;R</td>
+        <td class="fixed">&nbsp;U</td>
         <td>-</td>
-        <td>Researchers and Community members are allowed access</td>
+        <td>all ordinary Users can access</td>
       </tr>
       <tr>
-        <td class="fixed">&nbsp;&nbsp;C</td>
-        <td>-</td>
-        <td>only Community members are allowed access (normally requires application to Depositor)</td>
-      </tr>
-      <tr>
-        <td class="fixed">&nbsp;&nbsp;&nbsp;S</td>
+        <td class="fixed">&nbsp;&nbsp;S</td>
         <td>-</td>
         <td>only Subscribers are allowed access (requires application to Depositor)</td>
       </tr>

--- a/DistFiles/SayMore.es.tmx
+++ b/DistFiles/SayMore.es.tmx
@@ -7024,22 +7024,10 @@
         <seg>Bajo el control del depositante</seg>
       </tuv>
     </tu>
-    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.C">
+    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.O">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>only Community members are allowed access (normally requires application to Depositor)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Sólo los miebros de la comunidad pueden acceder (generalmente requiere llenar una solicitud al depositante)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.R">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Researchers and Community members are allowed access</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Los investigadores y los miebros de la comunidad pueden acceder</seg>
+        <seg>Open to unregistered visitors</seg>
       </tuv>
     </tu>
     <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.S">
@@ -7054,7 +7042,7 @@
     <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.U">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>all Users can access</seg>
+        <seg>all ordinary Users can access</seg>
       </tuv>
       <tuv xml:lang="es">
         <seg>todos los Usuarios pueden acceder</seg>

--- a/DistFiles/SayMore.fr.tmx
+++ b/DistFiles/SayMore.fr.tmx
@@ -7179,22 +7179,10 @@
         <seg>Contrôle du Déposant</seg>
       </tuv>
     </tu>
-    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.C">
+    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.O">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>only Community members are allowed access (normally requires application to Depositor)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>seuls les membres de la communauté sont autorisés à accéder (exige normalement une demande au Déposant)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.R">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Researchers and Community members are allowed access</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>les chercheurs et les membres de la communauté sont autorisés à accéder</seg>
+        <seg>Open to unregistered visitors</seg>
       </tuv>
     </tu>
     <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.S">
@@ -7209,7 +7197,7 @@
     <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.U">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>all Users can access</seg>
+        <seg>all ordinary Users can access</seg>
       </tuv>
       <tuv xml:lang="fr">
         <seg>tous les utilisateurs peuvent accéder</seg>

--- a/DistFiles/SayMore.pt.tmx
+++ b/DistFiles/SayMore.pt.tmx
@@ -7169,22 +7169,10 @@
         <seg>Controle do depositante</seg>
       </tuv>
     </tu>
-    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.C">
+    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.O">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>only Community members are allowed access (normally requires application to Depositor)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>acesso restrito a membros da comunidade (necessária permissão do depositante)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.R">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Researchers and Community members are allowed access</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Aceso liberado para pesquisadores e membros da comuniade</seg>
+        <seg>Open to unregistered visitors</seg>
       </tuv>
     </tu>
     <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.S">
@@ -7199,7 +7187,7 @@
     <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.U">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>all Users can access</seg>
+        <seg>all ordinary Users can access</seg>
       </tuv>
       <tuv xml:lang="pt">
         <seg>acesso liberado para todos os usuários</seg>

--- a/DistFiles/SayMore.ru.tmx
+++ b/DistFiles/SayMore.ru.tmx
@@ -7201,22 +7201,10 @@ A или запись согласия covering
         <seg>Kонтроль депонента</seg>
       </tuv>
     </tu>
-    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.C">
+    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.O">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>only Community members are allowed access (normally requires application to Depositor)</seg>
-      </tuv>
-      <tuv xml:lang="ru">
-        <seg>Только абонентам разрешен доступ (обычно требуется заявление Депозитору)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.R">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Researchers and Community members are allowed access</seg>
-      </tuv>
-      <tuv xml:lang="ru">
-        <seg> Доступ разрешен исследователям и членам общественности</seg>
+        <seg>Open to unregistered visitors</seg>
       </tuv>
     </tu>
     <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.S">
@@ -7231,7 +7219,7 @@ A или запись согласия covering
     <tu tuid="SessionsView.MetadataEditor.AccessProtocol.ELAR.U">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>all Users can access</seg>
+        <seg>all ordinary Users can access</seg>
       </tuv>
       <tuv xml:lang="ru">
         <seg>все пользователи могут получить доступ</seg>


### PR DESCRIPTION
The site https://www.soas.ac.uk/elar/using-elar/access-protocol/
outlines the updated ELAR protocol:
Open to unregistered visitors
all ordinary Users
Subscribers (requires depositor permission)

Card: https://trello.com/c/VGaP64Tv

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/26)
<!-- Reviewable:end -->
