### PR TITLE
Remove Iso639Code from the project model

### DIFF
--- a/src/SayMore/Model/Project.cs
+++ b/src/SayMore/Model/Project.cs
@@ -233,7 +233,6 @@ namespace SayMore.Model
 		public void Save()
 		{
 			var project = new XElement("Project");
-			project.Add(new XElement("Iso639Code", Iso639Code.NullTrim()));
 
 			project.Add(!TranscriptionFont.Equals(Program.DialogFont)
 				? new XElement("transcriptionFont", FontHelper.FontToString(TranscriptionFont))
@@ -385,15 +384,7 @@ namespace SayMore.Model
 
 			var project = XElement.Load(SettingsFilePath);
 
-			var settingValue = GetStringSettingValue(project, "Iso639Code", null);
-
-			if (string.IsNullOrEmpty(settingValue))
-				settingValue = GetStringSettingValue(project, "IsoCode", null); //old value when we were called "Sponge"
-
-			if (!string.IsNullOrEmpty(settingValue))
-				Iso639Code = settingValue;
-
-			settingValue = GetStringSettingValue(project, "transcriptionFont", null);
+			var settingValue = GetStringSettingValue(project, "transcriptionFont", null);
 			if (!string.IsNullOrEmpty(settingValue))
 			{
 				TranscriptionFont = FontHelper.MakeFont(settingValue);
@@ -467,14 +458,6 @@ namespace SayMore.Model
 			if (key != string.Empty)
 				bldr.Insert(0, "__Contributors__");
 		}
-
-		/// ------------------------------------------------------------------------------------
-		/// <summary>
-		/// This is, roughly, the "ethnologue code", taken either from 639-2 (2 letters),
-		/// or, more often, 639-3 (3 letters)
-		/// </summary>
-		/// ------------------------------------------------------------------------------------
-		public string Iso639Code { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>

--- a/src/SayMoreTests/model/ProjectTests.cs
+++ b/src/SayMoreTests/model/ProjectTests.cs
@@ -143,22 +143,6 @@ namespace SayMoreTests.Model
 			_parentFolder = null;
 		}
 
-		[Test]
-		[RequiresSTA]
-		public void Load_AfterSave_IsoPreserved()
-		{
-			string settingsPath = _parentFolder.Combine("foo." + Project.ProjectSettingsFileExtension);
-			var project = new Project(settingsPath, GetSessionRepo,
-				_projectContext.ResolveForTests<SessionFileType>());
-			project.Iso639Code = "abc";
-			project.Save();
-
-			var project2 = new Project(settingsPath,
-				_projectContext.ResolveForTests<ElementRepository<Session>.Factory>(),
-				_projectContext.ResolveForTests<SessionFileType>());
-			Assert.AreEqual("abc", project2.Iso639Code);
-		}
-
 		private ElementRepository<Session> GetSessionRepo(string projectDirectory, string elementGroupName, FileType type)
 		{
 			var repo = new Mock<ElementRepository<Session>>(projectDirectory, elementGroupName, type,


### PR DESCRIPTION
This is an obsolete value, replaced by VernacularISO3CodeAndName and
AnalysisISO3CodeAndName some time ago.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/64)
<!-- Reviewable:end -->
