### PR TITLE
Don't crash IMDI export when working language not set

### DIFF
--- a/src/SayMore/Model/ArchivingHelper.cs
+++ b/src/SayMore/Model/ArchivingHelper.cs
@@ -172,7 +172,9 @@ namespace SayMore.Model
 			var sessionFile = saymoreSession.MetaDataFile;
 			if (Project == null)
 				Project = Program.CurrentProject;
-			var analysisLanguage = (Project != null) ? Project.AnalysisISO3CodeAndName : AnalysisLanguage();
+			var analysisLanguage = Project?.AnalysisISO3CodeAndName;
+			if (string.IsNullOrEmpty(analysisLanguage))
+				analysisLanguage = AnalysisLanguage();
 			if (analysisLanguage.Contains(":"))
 				analysisLanguage = analysisLanguage.Split(':')[0];
 			analysisLanguage = ForceIso639ThreeChar(analysisLanguage);


### PR DESCRIPTION
Fall back to using the current UI language for export in that situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/65)
<!-- Reviewable:end -->
