### PR TITLE
Before forcing 3-letter code, strip code suffixes

### DIFF
--- a/src/SayMore/Model/ArchivingHelper.cs
+++ b/src/SayMore/Model/ArchivingHelper.cs
@@ -177,6 +177,8 @@ namespace SayMore.Model
 				analysisLanguage = AnalysisLanguage();
 			if (analysisLanguage.Contains(":"))
 				analysisLanguage = analysisLanguage.Split(':')[0];
+			// In case of things like pt-PT; no-op if no hyphen
+			analysisLanguage = analysisLanguage.Split('-')[0];
 			analysisLanguage = ForceIso639ThreeChar(analysisLanguage);
 
 			// create IMDI session


### PR DESCRIPTION
Makes sure we get an actual language code, not one with locale or other subcategories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/66)
<!-- Reviewable:end -->
