### PR TITLE
Don't use project language as default for Actor languages

### DIFF
--- a/src/SayMore/Model/ArchivingHelper.cs
+++ b/src/SayMore/Model/ArchivingHelper.cs
@@ -421,15 +421,7 @@ namespace SayMore.Model
 				{
 					EnglishName = language.EnglishName
 				};
-			else if (Project != null)
-			{
-				var archivingLanguage = ParseLanguage(ForceIso639ThreeChar(Project.VernacularISO3CodeAndName), null);
-				returnValue = new ArchivingLanguage(ForceIso639ThreeChar(archivingLanguage.Iso3Code), archivingLanguage.LanguageName)
-				{
-					EnglishName = archivingLanguage.EnglishName
-				};
-			}
-			return returnValue;
+		return returnValue;
 		}
 
 		internal static ArchivingActor InitializeActor(ArchivingDlgViewModel model, Person person, DateTime sessionDateTime, string role)

--- a/src/SayMoreTests/model/SessionArchivingTests.cs
+++ b/src/SayMoreTests/model/SessionArchivingTests.cs
@@ -275,29 +275,17 @@ namespace SayMoreTests.Utilities
 		}
 
 		[Test]
-		public void GetOneLanguage_DefaultIso_ReturnsCodeAndName()
+		public void GetOneLanguage_UnknownLanguageCodeOrName_ReturnsNull()
 		{
+			// Putting a language on the project because at one time this was a default value for GetOneLanguage.
+			// But even if the project has a language, and unknown language is unknown.
 			var project = new Mock<Project>(MockBehavior.Strict, Path.Combine(Path.GetTempPath(), "foo", "foo." + Project.ProjectSettingsFileExtension), null, null);
 			project.Object.VernacularISO3CodeAndName = "tru:Turoyo";
 			ArchivingHelper.Project = project.Object;
 			var returnValue = ArchivingHelper.GetOneLanguage("tru");
-			Assert.AreEqual("tru", returnValue.Iso3Code);
-			Assert.AreEqual("Turoyo", returnValue.LanguageName);
-			Assert.AreEqual("Turoyo", returnValue.EnglishName);
-			ArchivingHelper.Project = null;
-		}
-
-		[Test]
-		public void GetOneLanguage_DefaultName_ReturnsCodeAndName()
-		{
-			var project = new Mock<Project>(MockBehavior.Strict, Path.Combine(Path.GetTempPath(), "foo", "foo." + Project.ProjectSettingsFileExtension), null, null);
-			project.Object.VernacularISO3CodeAndName = "tru:Turoyo";
-			ArchivingHelper.Project = project.Object;
-			var returnValue = ArchivingHelper.GetOneLanguage("Turoyo");
-			Assert.AreEqual("tru", returnValue.Iso3Code);
-			Assert.AreEqual("Turoyo", returnValue.LanguageName);
-			Assert.AreEqual("Turoyo", returnValue.EnglishName);
-			ArchivingHelper.Project = null;
+			Assert.That(returnValue, Is.Null);
+			returnValue = ArchivingHelper.GetOneLanguage("Turoyo");
+			Assert.That(returnValue, Is.Null);
 		}
 
 		/// <see cref="en.wikipedia.org/wiki/List_of_ISO_639-2_codes"/>


### PR DESCRIPTION
If a Person does not have a specified primary or mother tongue language, don't just assume it is the project vernacular language (in IMDI export)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/71)
<!-- Reviewable:end -->
