### PR TITLE
Update package versions

### DIFF
--- a/CopyLibaries.bat
+++ b/CopyLibaries.bat
@@ -2,11 +2,10 @@ REM For this to work, you need palaso as a sibling of this project
 set palaso=libpalaso
 if NOT EXIST ..\%palaso% set palaso=palaso
 
-copy /Y ..\%palaso%\output\debug\icu.net.dll.config lib\dotnet
 copy /Y ..\%palaso%\output\debug\icu.net.dll lib\dotnet
-copy /Y ..\%palaso%\output\debug\icudt56.dll lib\dotnet
-copy /Y ..\%palaso%\output\debug\icuin56.dll lib\dotnet
-copy /Y ..\%palaso%\output\debug\icuuc56.dll lib\dotnet
+copy /Y ..\%palaso%\output\debug\lib\win-x64\icudt56.dll lib\dotnet
+copy /Y ..\%palaso%\output\debug\lib\win-x64\icuin56.dll lib\dotnet
+copy /Y ..\%palaso%\output\debug\lib\win-x64\icuuc56.dll lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.Core.dll lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.Core.pdb lib\dotnet
 copy /Y ..\%palaso%\output\debug\Interop.WIA.dll lib\dotnet
@@ -18,24 +17,16 @@ copy /Y ..\%palaso%\output\debug\SIL.Windows.Forms.dll lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.Windows.Forms.pdb lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.Archiving.dll lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.Archiving.pdb lib\dotnet
-copy /Y ..\%palaso%\output\debug\Ionic.Zip.dll lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.Windows.Forms.WritingSystems.dll lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.Windows.Forms.WritingSystems.pdb lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.WritingSystems.dll lib\dotnet
 copy /Y ..\%palaso%\output\debug\SIL.WritingSystems.pdb lib\dotnet
-copy /Y ..\%palaso%\output\debug\icu.net.dll lib\dotnet
-copy /Y ..\%palaso%\output\debug\icudt56.dll lib\dotnet
-copy /Y ..\%palaso%\output\debug\icuin56.dll lib\dotnet
-copy /Y ..\%palaso%\output\debug\icuuc56.dll lib\dotnet
 
 copy /Y ..\L10NSharp\Output\Debug\L10NSharp.dll lib\dotnet
 copy /Y ..\L10NSharp\Output\Debug\L10NSharp.pdb lib\dotnet
 
-copy /Y ..\%palaso%\output\debug\Palaso.BuildTasks.dll build
-
 REM now copy all that stuff to the debug folder
 copy /Y lib\dotnet\icu*.dll output\debug
-copy /Y lib\dotnet\Ionic.Zip.dll output\debug
 copy /Y lib\dotnet\SIL.* output\debug
 copy /Y lib\dotnet\L10NSharp.* output\debug
 

--- a/src/SayMore/SayMore.csproj
+++ b/src/SayMore/SayMore.csproj
@@ -69,9 +69,8 @@
       <HintPath>..\..\packages\Autofac.4.1.1\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DesktopAnalytics, Version=1.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DesktopAnalytics.1.2.3\lib\net40\DesktopAnalytics.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DesktopAnalytics, Version=1.2.4.11, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DesktopAnalytics.1.2.4.11\lib\net40\DesktopAnalytics.dll</HintPath>
     </Reference>
     <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <HintPath>..\..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
@@ -98,7 +97,7 @@
       <HintPath>..\..\lib\dotnet\NAudio.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/SayMore/packages.config
+++ b/src/SayMore/packages.config
@@ -2,12 +2,12 @@
 <packages>
   <package id="Analytics" version="2.0.2" targetFramework="net40-Client" />
   <package id="Autofac" version="4.1.1" targetFramework="net461" />
-  <package id="DesktopAnalytics" version="1.2.3" targetFramework="net461" />
+  <package id="DesktopAnalytics" version="1.2.4.11" targetFramework="net461" />
   <package id="DotNetZip" version="1.11.0" targetFramework="net461" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net4-client" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="SIL.BuildTasks" version="2.1.0" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
 </packages>

--- a/src/SayMoreTests/SayMoreTests.csproj
+++ b/src/SayMoreTests/SayMoreTests.csproj
@@ -73,8 +73,8 @@
     <Reference Include="NAudio">
       <HintPath>..\..\lib\dotnet\NAudio.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/src/SayMoreTests/app.config
+++ b/src/SayMoreTests/app.config
@@ -19,7 +19,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />

--- a/src/SayMoreTests/packages.config
+++ b/src/SayMoreTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Autofac" version="4.1.1" targetFramework="net461" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Fixed mismatch in version between tests and production DLL that was causing the wrong version of Newtonsoft.json.dll to get installed.
Also upgraded (minor version) to newest DesktopAnalytics.