### PR TITLE
Don't store roles as part of the file Participants list

### DIFF
--- a/src/SayMore/Model/Fields/ContributionSerializer.cs
+++ b/src/SayMore/Model/Fields/ContributionSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Xml.Linq;
+using SayMore.Model.Files;
 using SIL.Extensions;
 using SIL.Reporting;
 using SIL.Windows.Forms.ClearShare;
@@ -20,7 +21,7 @@ namespace SayMore.Model.Fields
 		private readonly OlacSystem _olacSystem = new OlacSystem();
 
 		/// ------------------------------------------------------------------------------------
-		public ContributionSerializer() : base("contributions")
+		public ContributionSerializer() : base(SessionFileType.kContributionsFieldName)
 		{
 		}
 

--- a/src/SayMore/Model/Files/FileType.cs
+++ b/src/SayMore/Model/Files/FileType.cs
@@ -190,7 +190,7 @@ namespace SayMore.Model.Files
 		/// ------------------------------------------------------------------------------------
 		public virtual bool GetShowInPresetOptions(string key)
 		{
-			return (!GetIsCustomFieldId(key) && !GetIsReadonly(key) && key != "contributions");
+			return (!GetIsCustomFieldId(key) && !GetIsReadonly(key) && key != SessionFileType.kContributionsFieldName);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -355,6 +355,7 @@ namespace SayMore.Model.Files
 		public const string kGenreFieldName = "genre";
 		public const string kParticipantsFieldName = "participants";
 		public const string kTitleFieldName = "title";
+		public const string kContributionsFieldName = "contributions";
 
 		// additional fields
 		public const string kCountryFieldName = XmlFileSerializer.kAdditionalFieldIdPrefix + "Location_Country";
@@ -434,7 +435,7 @@ namespace SayMore.Model.Files
 					kGenreFieldName,
 					kParticipantsFieldName,
 					kTitleFieldName,
-					"contributions",
+					kContributionsFieldName,
 					kInteractivityFieldName,
 					kInvolvementFieldName,
 					kCountryFieldName,
@@ -701,7 +702,7 @@ namespace SayMore.Model.Files
 
 				yield return new FieldDefinition("Device");
 				yield return new FieldDefinition("Microphone");
-				yield return new FieldDefinition("contributions");
+				yield return new FieldDefinition(SessionFileType.kContributionsFieldName);
 			}
 		}
 
@@ -855,7 +856,7 @@ namespace SayMore.Model.Files
 			var system = new OlacSystem();
 			var role = system.GetRoleByCodeOrThrow(roleCode);
 			var collection =
-				file.GetValue("contributions", new ContributionCollection()) as ContributionCollection;
+				file.GetValue(SessionFileType.kContributionsFieldName, new ContributionCollection()) as ContributionCollection;
 
 			var contributor = new Contribution(value, role);
 			contributor.Date = file.GetCreateDate();
@@ -863,7 +864,7 @@ namespace SayMore.Model.Files
 			{
 				collection.Add(contributor);
 				string failureMessage;
-				file.SetValue("contributions", collection, out failureMessage);
+				file.SetValue(SessionFileType.kContributionsFieldName, collection, out failureMessage);
 			}
 			file.RemoveField(fieldId);
 			file.Save();

--- a/src/SayMore/Model/Project.cs
+++ b/src/SayMore/Model/Project.cs
@@ -348,7 +348,7 @@ namespace SayMore.Model
 					model.SetAbstract(value, string.Empty);
 
 				// Set contributors
-				var contributions = session.MetaDataFile.GetValue("contributions", null) as ContributionCollection;
+				var contributions = session.MetaDataFile.GetValue(SessionFileType.kContributionsFieldName, null) as ContributionCollection;
 				if (contributions != null && contributions.Count > 0)
 					model.SetContributors(contributions);
 

--- a/src/SayMore/Program.cs
+++ b/src/SayMore/Program.cs
@@ -186,6 +186,7 @@ namespace SayMore
 			Logger.WriteEvent(ApplicationContainer.GetVersionInfo("SayMore version {0}.{1}.{2} {3}    Built on {4}", BuildType.Current));
 			Logger.WriteEvent("Visual Styles State: {0}", Application.VisualStyleState);
 			SetUpErrorHandling();
+			Sldr.Initialize();
 
 			var userInfo = new UserInfo();
 
@@ -218,8 +219,6 @@ namespace SayMore
 
 				if (!startedWithCommandLineProject)
 					StartUpShellBasedOnMostRecentUsedIfPossible();
-
-				Sldr.Initialize();
 
 				try
 				{

--- a/src/SayMoreTests/SayMoreTests.csproj
+++ b/src/SayMoreTests/SayMoreTests.csproj
@@ -227,11 +227,17 @@
     <EmbeddedResource Include="model\Data\Qustan059.session" />
     <EmbeddedResource Include="model\Data\Qustan059.WAV.meta" />
     <EmbeddedResource Include="model\Data\Qustan059_Source.mp4.meta" />
+    <EmbeddedResource Include="model\Data\MixedSession.session" />
     <None Include="packages.config" />
     <None Include="Resources\longerSound.wav" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="model\Data\OldSession.session">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/SayMoreTests/model/Data/MixedSession.session
+++ b/src/SayMoreTests/model/Data/MixedSession.session
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Session>
+	<title type="string">Beth Qustan Remained Unconquered</title>
+	<participants type="string">Iskender Demirel (editor);Joe;</participants>
+	<access type="string">S</access>
+	<status type="string">Finished</status>
+	<stage_consent type="string">NotComplete</stage_consent>
+	<contributions type="xml">
+		<contributor>
+			<name>Iskender Demirel</name>
+			<role>consultant</role>
+			<date>0001-01-01</date>
+			<notes>
+			</notes>
+		</contributor>
+		<contributor>
+			<name>Lahdo Agirman</name>
+			<role>consultant</role>
+			<date>2018-02-23</date>
+			<notes>
+			</notes>
+		</contributor>
+	</contributions>
+</Session>

--- a/src/SayMoreTests/model/Data/OldSession.session
+++ b/src/SayMoreTests/model/Data/OldSession.session
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Session>
+	<title type="string">Beth Qustan Remained Unconquered</title>
+	<participants type="string">Iskender Demirel;Lahdo Agirman;Iskender Demirel;</participants>
+	<access type="string">S</access>
+	<status type="string">Finished</status>
+	<stage_consent type="string">NotComplete</stage_consent>
+</Session>

--- a/src/SayMoreTests/model/Fields/ContributionCollectionTests.cs
+++ b/src/SayMoreTests/model/Fields/ContributionCollectionTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using SayMore.Model.Files;
 using SIL.Windows.Forms.ClearShare;
 
 namespace SayMoreTests.Model.Fields
@@ -39,14 +40,14 @@ namespace SayMoreTests.Model.Fields
 		public void GetValueForKey_EmptyList_ReturnsNull()
 		{
 			_contributions = new ContributionCollection();
-			Assert.IsNull(_contributions.GetValueForKey("contributions"));
+			Assert.IsNull(_contributions.GetValueForKey(SessionFileType.kContributionsFieldName));
 		}
 
 		/// ------------------------------------------------------------------------------------
 		[Test]
 		public void GetValueForKey_CorrectKey_ReturnsNameString()
 		{
-			var names = _contributions.GetValueForKey("contributions");
+			var names = _contributions.GetValueForKey(SessionFileType.kContributionsFieldName);
 			Assert.IsTrue(names.Contains("Leroy"));
 			Assert.IsTrue(names.Contains("Jed"));
 			Assert.IsTrue(names.Contains("Art"));

--- a/src/SayMoreTests/model/SessionTests.cs
+++ b/src/SayMoreTests/model/SessionTests.cs
@@ -10,6 +10,7 @@ using SayMore.Model.Files;
 using System.Linq;
 using System.Collections.Generic;
 using SayMore.Utilities;
+using SIL.Windows.Forms.ClearShare;
 
 namespace SayMoreTests.Model
 {
@@ -46,10 +47,14 @@ namespace SayMoreTests.Model
 				{
 					var file = new Mock<ProjectElementComponentFile>();
 					file.Setup(f => f.Save());
-					file.Setup(
-						f => f.GetStringValue(SessionFileType.kParticipantsFieldName, string.Empty)).
-						Returns(participants.Count() > 0 ? participants.Aggregate((a, b) => a + ";" + b) : string.Empty
-						);
+					//file.Setup(
+					//	f => f.GetStringValue(SessionFileType.kParticipantsFieldName, string.Empty)).
+					//	Returns(participants.Count() > 0 ? participants.Aggregate((a, b) => a + ";" + b) : string.Empty
+					//	);
+					var contributions = new Mock<ContributionCollection>(MockBehavior.Strict);
+					foreach (var p in participants)
+						contributions.Object.Add(new Contribution(p, new Role("par", "Participant", null)));
+					file.Setup(f => f.GetValue(SessionFileType.kContributionsFieldName, null)).Returns(contributions.Object);
 
 					if (additionalSetup != null)
 					{


### PR DESCRIPTION
In general, attempts to remove use of the Participants list except to maintain it for backwards compatibility. Instead, we derive the data from Contributions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/81)
<!-- Reviewable:end -->
