### PR TITLE
SP-2118: FieldWorks installs an incompatible version

### DIFF
--- a/src/Installer/Installer.wxs
+++ b/src/Installer/Installer.wxs
@@ -263,6 +263,14 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 		  <Component Id="MarkdownDeep.dll" Guid="{ed7e13b3-7a16-4af9-8d5b-ea7f7cb9bf03}">
 			<File Id="MarkdownDeep.dll" Name="MarkdownDeep.dll" KeyPath="yes" Source="..\..\output\release\MarkdownDeep.dll" />
 		  </Component>
+
+		  <Component Id="Microsoft.Extensions.DependencyModel.dll" Guid="{07090935-D28C-42F6-9395-38E8A27D4EA7}">
+			<File Id="Microsoft.Extensions.DependencyModel.dll" Name="Microsoft.Extensions.DependencyModel.dll" KeyPath="yes" Source="..\..\output\release\Microsoft.Extensions.DependencyModel.dll" />
+		  </Component>
+
+		  <Component Id="Microsoft.DotNet.PlatformAbstractions.dll" Guid="{62EBE0F0-6E20-4C16-ABF0-01A6C5CB5B8B}">
+			<File Id="Microsoft.DotNet.PlatformAbstractions.dll" Name="Microsoft.DotNet.PlatformAbstractions.dll" KeyPath="yes" Source="..\..\output\release\Microsoft.DotNet.PlatformAbstractions.dll" />
+		  </Component>
 		</Directory>
 	  </Directory>
 	</Directory>
@@ -299,8 +307,10 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 	  <ComponentRef Id="icudt56.dll"/>
 	  <ComponentRef Id="icuin56.dll"/>
 	  <ComponentRef Id="icuuc56.dll"/>
-		<ComponentRef Id="MarkdownDeep.dll"/>
-		<ComponentGroupRef Id="DistFiles"/>
+	  <ComponentRef Id="MarkdownDeep.dll"/>
+	  <ComponentRef Id="Microsoft.Extensions.DependencyModel.dll"/>
+	  <ComponentRef Id="Microsoft.DotNet.PlatformAbstractions.dll"/>
+	  <ComponentGroupRef Id="DistFiles"/>
 	</Feature>
 
 	<Media Id="1" Cabinet="product.cab" EmbedCab="yes" />


### PR DESCRIPTION
The version of Microsoft.Extensions.DependencyModel.dll shipping with Fieldworks is not compatible with SayMore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/102)
<!-- Reviewable:end -->
