### PR TITLE
Update DotNetZip

### DIFF
--- a/src/SayMore/SayMore.csproj
+++ b/src/SayMore/SayMore.csproj
@@ -70,8 +70,8 @@
     <Reference Include="DesktopAnalytics, Version=1.2.4.11, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\DesktopAnalytics.1.2.4.11\lib\net40\DesktopAnalytics.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.13.3.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetZip.1.13.3\lib\net40\DotNetZip.dll</HintPath>
     </Reference>
     <Reference Include="icu.net, Version=1.2.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/SayMore/packages.config
+++ b/src/SayMore/packages.config
@@ -3,7 +3,7 @@
   <package id="Analytics" version="2.0.2" targetFramework="net40-Client" />
   <package id="Autofac" version="4.1.1" targetFramework="net461" />
   <package id="DesktopAnalytics" version="1.2.4.11" targetFramework="net461" />
-  <package id="DotNetZip" version="1.11.0" targetFramework="net461" />
+  <package id="DotNetZip" version="1.13.3" targetFramework="net461" />
   <package id="L10NSharp" version="4.0.2" targetFramework="net461" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net4-client" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />


### PR DESCRIPTION
Was receiving this error during unit test execution with version 1.11.0: 

`the located assembly's manifest definition does not match the assembly reference`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/111)
<!-- Reviewable:end -->
