### PR TITLE
SP-2171: Object reference error opening progress form

### DIFF
--- a/src/SayMore/UI/Overview/Statistics/StatisticsViewModel.cs
+++ b/src/SayMore/UI/Overview/Statistics/StatisticsViewModel.cs
@@ -119,8 +119,9 @@ namespace SayMore.UI.Overview.Statistics
 
 		private IEnumerable<MediaFileInfo> GetFilteredFileData(ComponentRole role)
 		{
+			// SP-2171: i.MediaFilePath will be empty if the file is zero length (see MediaFileInfo.GetInfo()). This happens often with the generated oral annotation file.
 			return _backgroundStatisticsGather.GetAllFileData()
-				.Where(i => !i.MediaFilePath.EndsWith(Settings.Default.OralAnnotationGeneratedFileSuffix) &&
+				.Where(i => !string.IsNullOrEmpty(i.MediaFilePath) && !i.MediaFilePath.EndsWith(Settings.Default.OralAnnotationGeneratedFileSuffix) &&
 				            role.IsMatch(i.MediaFilePath));
 		}
 


### PR DESCRIPTION
i.MediaFilePath will be empty if the file is zero length. This happens often with the generated oral annotation file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/115)
<!-- Reviewable:end -->
