### PR TITLE
SP-2186: Prevent crash when user tries to rename component file

### DIFF
--- a/src/SayMore/Model/Files/ComponentFile.cs
+++ b/src/SayMore/Model/Files/ComponentFile.cs
@@ -4,14 +4,12 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Windows.Forms;
 using DesktopAnalytics;
 using L10NSharp;
 using SIL.Code;
 using SIL.Reporting;
 using SIL.Windows.Forms.FileSystem;
-using SIL.Windows.Forms.Miscellaneous;
 using SayMore.Media.Audio;
 using SayMore.Model.Fields;
 using SayMore.Model.Files.DataGathering;
@@ -20,6 +18,7 @@ using SayMore.Transcription.Model;
 using SayMore.Transcription.UI;
 using SayMore.UI.ElementListScreen;
 using SayMore.Utilities;
+using System.ComponentModel;
 
 namespace SayMore.Model.Files
 {
@@ -65,6 +64,9 @@ namespace SayMore.Model.Files
 		public delegate void ValueChangedHandler(ComponentFile file, string fieldId, object oldValue, object newValue);
 		public event ValueChangedHandler IdChanged;
 		public event ValueChangedHandler MetadataValueChanged;
+
+		public delegate void RenamingHandler(ComponentFile sender, CancelEventArgs e);
+		public event RenamingHandler StartingRename;
 
 		public event EventHandler BeforeSave;
 		public event EventHandler AfterSave;
@@ -783,6 +785,20 @@ namespace SayMore.Model.Files
 				PostGenerateOralAnnotationFileAction(generated);
 
 			return generated;
+		}
+
+		public bool IsOkayToRename 
+		{
+			get
+			{
+				if (StartingRename != null)
+				{
+					var args = new CancelEventArgs();
+					StartingRename(this, args);
+					return !args.Cancel;
+				}
+				return true;
+			}
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/SayMore/UI/ComponentEditors/ContributorsEditor.cs
+++ b/src/SayMore/UI/ComponentEditors/ContributorsEditor.cs
@@ -33,6 +33,8 @@ namespace SayMore.UI.ComponentEditors
 			InitializeComponent();
 			Name = "Contributors";
 
+			file.StartingRename += File_StartingRename;
+
 			_model = new ContributorsListControlViewModel(autoCompleteProvider, SaveContributors);
 			var dataGridView = new DataGridView();
 			dataGridView.Columns[dataGridView.Columns.Add("date", "date")].Visible = false;
@@ -61,6 +63,16 @@ namespace SayMore.UI.ComponentEditors
 
 			if (personInformant != null)
 				personInformant.PersonUiIdChanged += HandlePersonsUiIdChanged;
+		}
+
+		private void File_StartingRename(ComponentFile sender, CancelEventArgs e)
+		{
+			e.Cancel = !IsOKToLeaveEditor;
+			if (e.Cancel)
+			{
+				_contributorsControl.Focus();
+				_contributorsControl.Validate();
+			}
 		}
 
 		private void AddSessionControls()
@@ -174,7 +186,9 @@ namespace SayMore.UI.ComponentEditors
 		/// ------------------------------------------------------------------------------------
 		public override sealed void SetComponentFile(ComponentFile file)
 		{
+			_file.StartingRename -= File_StartingRename;
 			base.SetComponentFile(file);
+			file.StartingRename += File_StartingRename;
 			_model.SetContributionList(file.GetValue(SessionFileType.kContributionsFieldName, null) as ContributionCollection);
 		}
 

--- a/src/SayMore/UI/ComponentEditors/ContributorsEditor.cs
+++ b/src/SayMore/UI/ComponentEditors/ContributorsEditor.cs
@@ -67,12 +67,9 @@ namespace SayMore.UI.ComponentEditors
 
 		private void File_StartingRename(ComponentFile sender, CancelEventArgs e)
 		{
-			e.Cancel = !IsOKToLeaveEditor;
+			e.Cancel = !_contributorsControl.Validate();
 			if (e.Cancel)
-			{
 				_contributorsControl.Focus();
-				_contributorsControl.Validate();
-			}
 		}
 
 		private void AddSessionControls()

--- a/src/SayMore/UI/ElementListScreen/ComponentFileGrid.cs
+++ b/src/SayMore/UI/ElementListScreen/ComponentFileGrid.cs
@@ -570,7 +570,7 @@ namespace SayMore.UI.ElementListScreen
 		{
 			// Clicking on a ToolStripItem doesn't take focus from whatever control had
 			// focus, but there are times in SayMore where it is important for a component
-			// editor to loose focus when one of these component file grid buttons is
+			// editor to lose focus when one of these component file grid buttons is
 			// clicked. Therefore, pass on focus to the grid if any of our ToolStripItems
 			// are clicked. See SP-285.
 			if (!_grid.Focused)
@@ -601,7 +601,7 @@ namespace SayMore.UI.ElementListScreen
 			var index = _grid.CurrentCellAddress.Y;
 			var file = (index >= 0 && index < _files.Count() ? _files.ElementAt(index) : null);
 
-			if (file == null)
+			if (file == null || !file.IsOkayToRename)
 			{
 				SystemSounds.Beep.Play();
 				return;


### PR DESCRIPTION
 and ContributorsEditor data is not in valid state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/122)
<!-- Reviewable:end -->
