### PR TITLE
Added UpdateDownloadInfo target as dependency on Installer

### DIFF
--- a/build/SayMore.proj
+++ b/build/SayMore.proj
@@ -112,7 +112,7 @@
 
   </Target>
 
-  <Target Name="Installer" DependsOnTargets="VersionNumbers; MakeWixForDistFiles; Build ">
+  <Target Name="Installer" DependsOnTargets="VersionNumbers; UpdateDownloadInfo; MakeWixForDistFiles; Build ">
 
 	<!-- set the version number in the installer configuration program.  Perhaps there's a way to just send in the variables rather than this brute-force
 		changing of the script, but I haven't figured that out. -->


### PR DESCRIPTION
Without this, the release build does not get this named and copied to the correct location and the new build does not appear on the download site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/124)
<!-- Reviewable:end -->
