### PR TITLE
SP-2228: Fixed calculation of total duration to not count both the source and "StandardAudio"

### DIFF
--- a/src/SayMore/MediaUtils/MediaFileInfo.cs
+++ b/src/SayMore/MediaUtils/MediaFileInfo.cs
@@ -117,7 +117,7 @@ namespace SayMore.Media
 		/// Gets the total duration in seconds. For audio files, the duration is always the
 		/// duration of the audio. For video files, it is the total duration, counting from the
 		/// start of the first track to the end of the last track (audio and video tracks are
-		/// not guaranteed to start and end simultaneouly).
+		/// not guaranteed to start and end simultaneously).
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public float DurationInSeconds

--- a/src/SayMore/Model/Files/DataGathering/SourceAndStandardAudioCoalescingComparer.cs
+++ b/src/SayMore/Model/Files/DataGathering/SourceAndStandardAudioCoalescingComparer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.IO;
+using SayMore.Media;
+
+namespace SayMore.Model.Files.DataGathering
+{
+	class SourceAndStandardAudioCoalescingComparer : IEqualityComparer<MediaFileInfo>
+	{
+		private Regex m_regexStandardAudio = new Regex(Properties.Settings.Default.StandardAudioFileSuffix + "$",
+			RegexOptions.Compiled | RegexOptions.IgnoreCase);
+	
+		public bool Equals(MediaFileInfo x, MediaFileInfo y)
+		{
+			if (ReferenceEquals(x, y))
+				return true;
+			if (ReferenceEquals(x, null))
+				return false;
+			if (ReferenceEquals(y, null))
+				return false;
+			if (x.GetType() != y.GetType())
+				return false;
+			if (Math.Abs(x.DurationInMilliseconds - y.DurationInMilliseconds) > 1500) // Somewhat arbitrary fudge factor
+				return false;
+			if (x.MediaFilePath.Equals(y.MediaFilePath))
+				return true;
+			var matchX = m_regexStandardAudio.Match(x.MediaFilePath);
+			if (matchX.Success)
+				return y.MediaFilePath.StartsWith(x.MediaFilePath.Substring(0, matchX.Index));
+			var matchY = m_regexStandardAudio.Match(y.MediaFilePath);
+			return matchY.Success && x.MediaFilePath.StartsWith(y.MediaFilePath.Substring(0, matchY.Index));
+		}
+
+		public int GetHashCode(MediaFileInfo obj)
+		{
+			unchecked
+			{
+				var directory = obj.MediaFilePath == null ? null : Path.GetDirectoryName(obj.MediaFilePath);
+				// We'd prefer to include the DurationInMilliseconds in the hashcode, but unfortunately a
+				// converted file can vary slightly in duration.
+				return directory != null ? directory.GetHashCode() : 0;
+			}
+		}
+	}
+}

--- a/src/SayMore/SayMore.csproj
+++ b/src/SayMore/SayMore.csproj
@@ -241,6 +241,7 @@
     <Compile Include="MediaUtils\Audio\AudioUtils.cs" />
     <Compile Include="MediaUtils\Audio\WaveFileReaderWrapper.cs" />
     <Compile Include="Model\ArchivingHelper.cs" />
+    <Compile Include="Model\Files\DataGathering\SourceAndStandardAudioCoalescingComparer.cs" />
     <Compile Include="Model\IIMDIArchivable.cs" />
     <Compile Include="Model\IRAMPArchivable.cs" />
     <Compile Include="ResourceImageCache.cs" />
@@ -1053,6 +1054,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UI\Overview\Statistics\StatisticsView.resx">
       <DependentUpon>StatisticsView.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\ProjectWindow\ShowHtmlDialog.resx">
       <DependentUpon>ShowHtmlDialog.cs</DependentUpon>

--- a/src/SayMore/Transcription/UI/ComponentEditors/ConvertToStandardAudioEditor.cs
+++ b/src/SayMore/Transcription/UI/ComponentEditors/ConvertToStandardAudioEditor.cs
@@ -28,9 +28,9 @@ namespace SayMore.Transcription.UI
 			// ENHANCE: I made the Dispose method for this class disposes of the Image. However,
 			// Dispose !never! gets called. This is not a huge bitmap, of course, but this
 			// constructor can get called quite a few times. It gets squirreled away in the _editors
-			// hastable in FileType using a cryptic hashcode from ElementListViewModel. But FileType
+			// hashtable in FileType using a cryptic hashcode from ElementListViewModel. But FileType
 			// is never disposed, nor is the hashtable ever cleared. So even when changing projects,
-			// it just contionues to grow. I'm not exactly sure how to fix this memory leak because
+			// it just continues to grow. I'm not exactly sure how to fix this memory leak because
 			// there's no obvious time when it makes sense to clear FileType._editors. I tried
 			// discarding editor providers for all component files of the selected element every time
 			// SelectedElement changed, but that caused the Contributors editor to appear blank and

--- a/src/SayMore/UI/Overview/Statistics/StatisticsView.Designer.cs
+++ b/src/SayMore/UI/Overview/Statistics/StatisticsView.Designer.cs
@@ -41,6 +41,7 @@ namespace SayMore.UI.Overview.Statistics
 			this._buttonCopy = new System.Windows.Forms.ToolStripButton();
 			this._buttonSave = new System.Windows.Forms.ToolStripButton();
 			this._buttonPrint = new System.Windows.Forms.ToolStripButton();
+			this._detectContextMenuRefreshTimer = new System.Windows.Forms.Timer(this.components);
 			this._panelBrowser.SuspendLayout();
 			this._panelWorking.SuspendLayout();
 			this._tableLayoutWorking.SuspendLayout();
@@ -247,6 +248,10 @@ namespace SayMore.UI.Overview.Statistics
 			this._buttonPrint.Text = "Print";
 			this._buttonPrint.Click += new System.EventHandler(this.HandlePrintButtonClicked);
 			// 
+			// _detectContectMenuRefreshTimer
+			// 
+			this._detectContextMenuRefreshTimer.Tick += new System.EventHandler(this._detectContextMenuRefreshTimer_Tick);
+			// 
 			// StatisticsView
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -288,5 +293,6 @@ namespace SayMore.UI.Overview.Statistics
 		private System.Windows.Forms.ToolStripButton _buttonCopy;
 		private System.Windows.Forms.ToolStripButton _buttonSave;
 		private System.Windows.Forms.ToolStripButton _buttonPrint;
-    }
+		private System.Windows.Forms.Timer _detectContextMenuRefreshTimer;
+	}
 }

--- a/src/SayMore/UI/Overview/Statistics/StatisticsView.cs
+++ b/src/SayMore/UI/Overview/Statistics/StatisticsView.cs
@@ -71,6 +71,8 @@ namespace SayMore.UI.Overview.Statistics
 							UpdateStatusDisplay(false);
 							_model.NewStatisticsAvailable -= HandleNewDataAvailable;
 							_model.NewStatisticsAvailable += HandleNewDataAvailable;
+
+							_detectContextMenuRefreshTimer.Enabled = true;
 						}));
 				});
 			updateDisplayThread.Name = "StatisticsView.UpdateDisplay";
@@ -81,6 +83,7 @@ namespace SayMore.UI.Overview.Statistics
 		/// ------------------------------------------------------------------------------------
 		private void UpdateStatusDisplay(bool working)
 		{
+			_detectContextMenuRefreshTimer.Enabled = false;
 			_buttonRefresh.Visible = !working;
 			_panelWorking.Visible = working;
 		}
@@ -176,6 +179,16 @@ namespace SayMore.UI.Overview.Statistics
 			// background thread is a no-no. UpdateDisplay will be called when the timer
 			// tick fires.
 			BeginInvoke(new Action(UpdateDisplay));
+		}
+
+		private void _detectContextMenuRefreshTimer_Tick(object sender, EventArgs e)
+		{
+			if (_webBrowser.DocumentText == "<HTML></HTML>\0")
+			{
+				// User must have used F5 or the context menu to refresh. This doesn't work,
+				// so now let's trigger the rel refresh.
+				HandleRefreshButtonClicked(sender, e);
+			}
 		}
 	}
 }

--- a/src/SayMore/UI/Overview/Statistics/StatisticsView.resx
+++ b/src/SayMore/UI/Overview/Statistics/StatisticsView.resx
@@ -123,4 +123,7 @@
   <metadata name="_toolStripActions.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>315, 17</value>
   </metadata>
+  <metadata name="_detectContextMenuRefreshTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>580, 22</value>
+  </metadata>
 </root>

--- a/src/SayMore/UI/Overview/Statistics/StatisticsViewModel.cs
+++ b/src/SayMore/UI/Overview/Statistics/StatisticsViewModel.cs
@@ -119,10 +119,12 @@ namespace SayMore.UI.Overview.Statistics
 
 		private IEnumerable<MediaFileInfo> GetFilteredFileData(ComponentRole role)
 		{
+			var comparer = new SourceAndStandardAudioCoalescingComparer();
 			// SP-2171: i.MediaFilePath will be empty if the file is zero length (see MediaFileInfo.GetInfo()). This happens often with the generated oral annotation file.
 			return _backgroundStatisticsGather.GetAllFileData()
 				.Where(i => !string.IsNullOrEmpty(i.MediaFilePath) && !i.MediaFilePath.EndsWith(Settings.Default.OralAnnotationGeneratedFileSuffix) &&
-				            role.IsMatch(i.MediaFilePath));
+					role.IsMatch(i.MediaFilePath))
+				.Distinct(comparer);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/SayMoreTests/SayMoreTests.csproj
+++ b/src/SayMoreTests/SayMoreTests.csproj
@@ -223,6 +223,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationContainerTests.cs" />
+    <Compile Include="model\Files\DataGathering\SourceAndStandardAudioCoalescingComparerTests.cs" />
     <Compile Include="MediaUtils\Audio\AudioFileHelperTests.cs" />
     <Compile Include="MediaUtils\Audio\OralAnnotationPlaybackWaveStreamTests.cs" />
     <Compile Include="model\SessionWorkflowInformantTests.cs" />

--- a/src/SayMoreTests/model/Files/DataGathering/SourceAndStandardAudioCoalescingComparerTests.cs
+++ b/src/SayMoreTests/model/Files/DataGathering/SourceAndStandardAudioCoalescingComparerTests.cs
@@ -1,0 +1,294 @@
+﻿using System.IO;
+using NUnit.Framework;
+using SayMore.Media;
+using SIL.Reflection;
+
+namespace SayMore.Model.Files.DataGathering
+{
+	[TestFixture]
+	class SourceAndStandardAudioCoalescingComparerTests
+	{
+		private SourceAndStandardAudioCoalescingComparer m_comparer = new SourceAndStandardAudioCoalescingComparer();
+
+		[Test]
+		public void Equals_TotallyDifferentAudioFiles_ReturnsFalse()
+		{
+			var file1 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", "SomePath_Source.mp3");
+			
+			var file2 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(2300),
+				DurationInMilliseconds = 2300,
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", "NotThatOne_StandardAudio.WAV");
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsFalse(m_comparer.Equals(file1, file2));
+			Assert.IsFalse(m_comparer.Equals(file2, file1));
+		}
+
+		[TestCase("")]
+		[TestCase(@"c:\MyPath\")]
+		public void Equals_VideoAndAudioFilesWithSameDurationButDifferentNames_ReturnsFalse(string path)
+		{
+			var file1 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", Path.Combine(path, "SomePath_StandardAudio.WAV"));
+			
+			var file2 = new MediaFileInfo
+			{
+				DurationInMilliseconds = 5500,
+				Video = new TestVideoInfo(5500)
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", Path.Combine(path, "NotThatOne_Source.mp4"));
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsFalse(m_comparer.Equals(file1, file2));
+			Assert.IsFalse(m_comparer.Equals(file2, file1));
+		}
+
+		[Test]
+		public void Equals_AudioFileAndNull_ReturnsFalse()
+		{
+			var file1 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", "SomePath_StandardAudio.WAV");
+			
+			Assert.IsFalse(m_comparer.Equals(file1, null));
+			Assert.IsFalse(m_comparer.Equals(null, file1));
+		}
+
+		[Test]
+		public void Equals_SameObject_ReturnsTrue()
+		{
+			var file1 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", "SomePath_Source.mp3");
+
+			Assert.IsTrue(m_comparer.Equals(file1, file1));
+		}
+
+		[Test]
+		public void Equals_IdenticalNameAndDuration_ReturnsTrue()
+		{
+			var file1 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", "SomePath_Source.mp3");
+			
+			var file2 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", "SomePath_Source.mp3");
+			// The following is probably impossible in practice, but it at least illustrates
+			// that this comparer is not checking all the fields we don't care about.
+			file1.LengthInBytes = 7;
+			file2.LengthInBytes = 7000;
+			file2.Audio.Channels = 6;
+			file2.Audio.CodecInformation = "None";
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsTrue(m_comparer.Equals(file1, file2));
+			Assert.IsTrue(m_comparer.Equals(file2, file1));
+		}
+
+		[Test]
+		public void Equals_IdenticalNameAndDurationWithDifferentPaths_ReturnsFalse()
+		{
+			var file1 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", @"c:\Documents\SayMore\Session2\SomePath_Source.mp3");
+			
+			var file2 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", @"c:\Documents\SayMore\Session3\SomePath_Source.mp3");
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.Not.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsFalse(m_comparer.Equals(file1, file2));
+			Assert.IsFalse(m_comparer.Equals(file2, file1));
+		}
+
+		[Test]
+		public void Equals_AudioSourceWithDerivedStandardAudioButDifferentPaths_ReturnsFalse()
+		{
+			var file1 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", @"c:\Documents\SayMore\Session2\SomePath_Source.mp3");
+			
+			var file2 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", @"c:\Documents\SayMore\Session3\SomePath_Source_StandardAudio.wav");
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.Not.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsFalse(m_comparer.Equals(file1, file2));
+			Assert.IsFalse(m_comparer.Equals(file2, file1));
+		}
+
+		[TestCase("")]
+		[TestCase(@"c:\MyPath")]
+		public void Equals_VideoSourceWithDerivedStandardAudio_ReturnsTrue(string path)
+		{
+			var file1 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", Path.Combine(path, "SomePath_Source.mp3"));
+			
+			var file2 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", Path.Combine(path, "SomePath_Source_StandardAudio.WAV"));
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsTrue(m_comparer.Equals(file1, file2));
+			Assert.IsTrue(m_comparer.Equals(file2, file1));
+		}
+
+		[Test]
+		public void Equals_AudioSourceWithDerivedStandardAudio_ReturnsTrue()
+		{
+			
+			var file1 = new MediaFileInfo
+			{
+				DurationInMilliseconds = 5500,
+				Video = new TestVideoInfo(5500)
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", "SomePath_Source.mp4");
+
+			var file2 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", "SomePath_Source_StandardAudio.WAV");
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsTrue(m_comparer.Equals(file1, file2));
+			Assert.IsTrue(m_comparer.Equals(file2, file1));
+		}
+
+		[TestCase(1501)]
+		[TestCase(-1501)]
+		public void Equals_AudioSourceWithDerivedStandardAudioNameButVeryDifferentDuration_ReturnsFalse(int difference)
+		{
+			// This is a really unlikely scenario, but it is possible (e.g., if the user trimmed one
+			// of the files after making the standard audio version). Hard to know how we'd want to
+			// deal with it in the statistics, but given how unlikely it is, treating them as not
+			// the same file and therefore counting both is probably marginally acceptable.
+			var file1 = new MediaFileInfo
+			{
+				DurationInMilliseconds = 5500 + difference,
+				Video = new TestVideoInfo(5500 + difference)
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", "SomePath_Source.mp4");
+
+			var file2 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", "SomePath_Source_StandardAudio.WAV");
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsFalse(m_comparer.Equals(file1, file2));
+			Assert.IsFalse(m_comparer.Equals(file2, file1));
+		}
+
+		[TestCase(-1)]
+		[TestCase(1)]
+		[TestCase(1500)]
+		public void Equals_AudioSourceWithDerivedStandardAudioNameButSlightlyDifferentDuration_ReturnsFalse(int difference)
+		{
+			// This is a really unlikely scenario, but it is possible (e.g., if the user trimmed one
+			// of the files after making the standard audio version). Hard to know how we'd want to
+			// deal with it in the statistics, but given how unlikely it is, treating them as not
+			// the same file and therefore counting both is probably marginally acceptable.
+			var file1 = new MediaFileInfo
+			{
+				DurationInMilliseconds = 5500 + difference,
+				Video = new TestVideoInfo(5500 + difference)
+			};
+			ReflectionHelper.SetProperty(file1, "MediaFilePath", "SomePath_Source.mp4");
+
+			var file2 = new MediaFileInfo
+			{
+				Audio = new TestAudioInfo(5500),
+				DurationInMilliseconds = 5500,
+			};
+			ReflectionHelper.SetProperty(file2, "MediaFilePath", "SomePath_Source_StandardAudio.WAV");
+
+			// In real life, Equals will not usually get called unless the hash codes are the same.
+			Assert.That(m_comparer.GetHashCode(file1), Is.EqualTo(m_comparer.GetHashCode(file2)));
+			Assert.IsTrue(m_comparer.Equals(file1, file2));
+			Assert.IsTrue(m_comparer.Equals(file2, file1));
+		}
+
+		private class TestAudioInfo : MediaFileInfo.AudioInfo
+		{
+			internal TestAudioInfo(int duration)
+			{
+				BitRate = 42;
+				BitRateMode = "freaky";
+				BitsPerSample = 9;
+				Channels = 1;
+				CodecInformation = "MP3";
+				DurationInMilliseconds = duration;
+				Encoding = "WAV";
+			}
+		}
+
+		private class TestVideoInfo : MediaFileInfo.VideoInfo
+		{
+			internal TestVideoInfo(int duration)
+			{
+				FramesPerSecond = 30;
+				BitRate = 42;
+				BitRateMode = "freaky";
+				CodecInformation = "MP4";
+				DurationInMilliseconds = duration;
+				Encoding = "Yes";
+			}
+		}
+	}
+}


### PR DESCRIPTION
Also fixed a little problem (using a bit of a hack) where using F5 or the context menu to refresh the statistics view made it go blank.