### PR TITLE
SP-2216: Added check for null MetaDataFile  in GetShouldReportHaveConsent

### DIFF
--- a/src/SayMore/Model/Session.cs
+++ b/src/SayMore/Model/Session.cs
@@ -219,7 +219,8 @@ namespace SayMore.Model
 		/// ------------------------------------------------------------------------------------
 		private bool GetShouldReportHaveConsent()
 		{
-			var contributions = MetaDataFile.GetValue(SessionFileType.kContributionsFieldName, null) as ContributionCollection;
+			// MetaDataFile can be null if this Session is already disposed (when called via OnPaint). 
+			var contributions = MetaDataFile?.GetValue(SessionFileType.kContributionsFieldName, null) as ContributionCollection;
 			var personNames = contributions?.Select(c => c.ContributorName).ToArray();
 			if (personNames == null)
 				return false;


### PR DESCRIPTION
This can happen when a session is disposed, but a late OnPaint accesses that method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/130)
<!-- Reviewable:end -->
