### PR TITLE
SP-2240: Fixed internationalization/localization problems that led to crash

### DIFF
--- a/DistFiles/SayMore.es.tmx
+++ b/DistFiles/SayMore.es.tmx
@@ -523,12 +523,28 @@
         <seg>Abrir {0} en su programa asociado.</seg>
       </tuv>
     </tu>
-    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsg">
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble">
       <tuv xml:lang="en">
-        <seg>&lt;HTML&gt;SayMore attempted to load:&lt;br /&gt;&lt;br /&gt;&lt;b&gt;File:&lt;/b&gt; {0}&lt;br /&gt;&lt;nobr&gt;&lt;b&gt;Folder:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/HTML&gt;</seg>
+        <seg>{0} attempted to load:</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>&lt;html&gt;SayMore intentado cargar:&lt;br&gt;&lt;br&gt;&lt;b&gt;Archivo:&lt;/b&gt; {0}&lt;br&gt;&lt;nobr&gt;&lt;b&gt;Carpeta:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/html&gt;</seg>
+        <seg>{0} intentó cargar:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileLabel">
+      <tuv xml:lang="en">
+        <seg>File:</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Archivo:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FolderLabel">
+      <tuv xml:lang="en">
+        <seg>Folder:</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Carpeta:</seg>
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.TabText">

--- a/DistFiles/SayMore.fr.tmx
+++ b/DistFiles/SayMore.fr.tmx
@@ -523,12 +523,28 @@
         <seg>Ouvrir {0} dans le logiciel associé.</seg>
       </tuv>
     </tu>
-    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsg">
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble">
       <tuv xml:lang="en">
-        <seg>&lt;HTML&gt;SayMore attempted to load:&lt;br /&gt;&lt;br /&gt;&lt;b&gt;File:&lt;/b&gt; {0}&lt;br /&gt;&lt;nobr&gt;&lt;b&gt;Folder:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/HTML&gt;</seg>
+        <seg>{0} attempted to load:</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>&lt;HTML&gt;SayMore a tenté de charger :&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Fichier :&lt;/b&gt; {0}&lt;br /&gt;&lt;nobr&gt;&lt;b&gt;Dossier :&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/HTML&gt;</seg>
+        <seg>{0} a tenté de charger :</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileLabel">
+      <tuv xml:lang="en">
+        <seg>File:</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Fichier :</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FolderLabel">
+      <tuv xml:lang="en">
+        <seg>Folder:</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Dossier :</seg>
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.TabText">

--- a/DistFiles/SayMore.pt.tmx
+++ b/DistFiles/SayMore.pt.tmx
@@ -531,12 +531,28 @@
         <seg>Abrir {0} em programa associado.</seg>
       </tuv>
     </tu>
-    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsg">
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble">
       <tuv xml:lang="en">
-        <seg>&lt;HTML&gt;SayMore attempted to load:&lt;br /&gt;&lt;br /&gt;&lt;b&gt;File:&lt;/b&gt; {0}&lt;br /&gt;&lt;nobr&gt;&lt;b&gt;Folder:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/HTML&gt;</seg>
+        <seg>{0} attempted to load:</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>&lt;HTML&gt;SayMore tentou carregar: &lt;br/&gt;&lt;br/&gt;&lt;b&gt;Arquivo: &lt;/b&gt; {0}&lt;br /&gt;&lt;nobr&gt;&lt;b&gt;Pasta:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/HTML&gt;</seg>
+        <seg>{0} tentou carregar:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileLabel">
+      <tuv xml:lang="en">
+        <seg>File:</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Arquivo:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FolderLabel">
+      <tuv xml:lang="en">
+        <seg>Folder:</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Pasta:</seg>
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.TabText">

--- a/DistFiles/SayMore.ru.tmx
+++ b/DistFiles/SayMore.ru.tmx
@@ -528,15 +528,31 @@
         <seg>Open {0} in its associated program.</seg>
       </tuv>
       <tuv xml:lang="ru">
-        <seg>&lt;html&gt;&lt;body&gt;Нажмите &lt;a href="file:///{0}"&gt;&lt;b&gt;здесь, чтобы открыть «{1}»&lt;/b&gt;&lt;/a&gt; в связанной с ним программе.&lt;/body&gt;&lt;/html&gt;</seg>
+        <seg>Откройте {0} в связанной с ним программе.</seg>
       </tuv>
     </tu>
-    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsg">
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble">
       <tuv xml:lang="en">
-        <seg>&lt;HTML&gt;SayMore attempted to load:&lt;br /&gt;&lt;br /&gt;&lt;b&gt;File:&lt;/b&gt; {0}&lt;br /&gt;&lt;nobr&gt;&lt;b&gt;Folder:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/HTML&gt;</seg>
+        <seg>{0} attempted to load:</seg>
       </tuv>
       <tuv xml:lang="ru">
-        <seg>&lt;html&gt;SayMore пытался загрузить:&lt;br&gt;&lt;br&gt;&lt;b&gt;Файл:&lt;/b&gt; {0}&lt;br&gt;&lt;nobr&gt;&lt;b&gt;Папку:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/html&gt;</seg>
+        <seg>{0} пытался загрузить:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileLabel">
+      <tuv xml:lang="en">
+        <seg>File:</seg>
+      </tuv>
+      <tuv xml:lang="ru">
+        <seg>Файл:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FolderLabel">
+      <tuv xml:lang="en">
+        <seg>Folder:</seg>
+      </tuv>
+      <tuv xml:lang="ru">
+        <seg>Папку:</seg>
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.TabText">

--- a/DistFiles/SayMore.tr.tmx
+++ b/DistFiles/SayMore.tr.tmx
@@ -563,12 +563,28 @@
         <seg>{0} ilişkili programında açın.</seg>
       </tuv>
     </tu>
-    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsg">
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble">
       <tuv xml:lang="en">
-        <seg>&lt;HTML&gt;SayMore attempted to load:&lt;br /&gt;&lt;br /&gt;&lt;b&gt;File:&lt;/b&gt; {0}&lt;br /&gt;&lt;nobr&gt;&lt;b&gt;Folder:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/HTML&gt;</seg>
+        <seg>{0} attempted to load:</seg>
       </tuv>
       <tuv xml:lang="tr">
-        <seg>&lt;HTML&gt;SayMore yüklemeye çalıştı:&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Dosya:&lt;/b&gt; {0}&lt;br /&gt;&lt;nobr&gt;&lt;b&gt;Klasör:&lt;/b&gt; {1}&lt;/nobr&gt;&lt;/HTML&gt;</seg>
+        <seg>{0} yüklemeye çalıştı:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FileLabel">
+      <tuv xml:lang="en">
+        <seg>File:</seg>
+      </tuv>
+      <tuv xml:lang="tr">
+        <seg>Dosya:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.FolderLabel">
+      <tuv xml:lang="en">
+        <seg>Folder:</seg>
+      </tuv>
+      <tuv xml:lang="tr">
+        <seg>Klasör:</seg>
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.TabText">

--- a/DistFiles/SayMore.zh-Hans.tmx
+++ b/DistFiles/SayMore.zh-Hans.tmx
@@ -472,7 +472,7 @@
         <seg>Open {0} in its associated program.</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>在关联程序中打开</seg>
+        <seg>在其关联的程序中打开 {0}。</seg>
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.GenericFileTypeViewer.TabText">

--- a/src/SayMore/ApplicationContainer.cs
+++ b/src/SayMore/ApplicationContainer.cs
@@ -15,6 +15,7 @@ using SayMore.Properties;
 using SayMore.UI;
 using SayMore.UI.ProjectChoosingAndCreating;
 using SayMore.Utilities;
+using SIL.Reporting;
 using static System.Char;
 
 namespace SayMore
@@ -209,6 +210,8 @@ namespace SayMore
 				Resources.SayMore, "sil.saymore@gmail.com", "SayMore", "SIL.Archiving", "SIL.Windows.Forms.FileSystem");
 
 			Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
+
+			Logger.WriteEvent("Initial UI Locale: " + Settings.Default.UserInterfaceLanguage);
 
 			return localizationManager;
 		}

--- a/src/SayMore/UI/ComponentEditors/BrowserEditor.cs
+++ b/src/SayMore/UI/ComponentEditors/BrowserEditor.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Windows.Forms;
 using L10NSharp;
 using SayMore.Model.Files;
@@ -85,13 +84,40 @@ namespace SayMore.UI.ComponentEditors
 			_browser.DocumentCompleted += HandleBrowserLoadCompleted;
 			_browser.Navigate("about:blank");
 
-			var msg = LocalizationManager.GetString("CommonToMultipleViews.GenericFileTypeViewer.FileNameMsg",
-				"<HTML>SayMore attempted to load:<br /><br /><b>File:</b> {0}<br /><nobr><b>Folder:</b> {1}</nobr></HTML>");
+			// REVIEW (TomB): Having just now fixed this so that localizing this is easier and
+			// less error-prone, I find that it is apparently impossible to get this HTML to be
+			// displayed. Looked back 10 years in the history and since this code was added on
+			// 6/21/2010, despite lots of editing, the basic logic represented here is unchanged.
+			// It's entirely possible that changing/differening browser behavior is the reason
+			// for it, so I'm going to play it safe and leave it here, but I'm guessing it can
+			// go away (and almost certainly isn't worth localizing). I am wrapping it in a try-
+			// catch block so that if there are future localization gaffs that would cause format
+			// errors they will be silently ignored. Can't see bringing down SayMore for an error
+			// that might occur in useless code.
+			try
+			{
+				var msgPreamble = string.Format(LocalizationManager.GetString(
+						"CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble",
+						"{0} attempted to load:", "Param is \"SayMore\" (program name)"),
+					Program.ProductName);
+				var fileLabel = LocalizationManager.GetString(
+					"CommonToMultipleViews.GenericFileTypeViewer.FileLabel", "File:");
+				var folderLabel = LocalizationManager.GetString(
+					"CommonToMultipleViews.GenericFileTypeViewer.FolderLabel", "Folder:");
 
-			msg = msg.Replace("\n", "<br />");
+				var msg = "<HTML>" + msgPreamble + "<br /><br /><b>" +
+					fileLabel + "</b> {0}<br /><nobr><b>" +
+					folderLabel + "</b> {1}</nobr></HTML>";
 
-			_browser.DocumentText = string.Format(msg,
-				Path.GetFileName(filePath), Path.GetDirectoryName(filePath));
+				msg = msg.Replace("\n", "<br />");
+
+				_browser.DocumentText = string.Format(msg,
+					Path.GetFileName(filePath), Path.GetDirectoryName(filePath));
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+			}
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/SayMore/UI/Overview/ProjectDocsScreen.cs
+++ b/src/SayMore/UI/Overview/ProjectDocsScreen.cs
@@ -11,6 +11,7 @@ using SayMore.Model.Files;
 using SayMore.Properties;
 using SayMore.UI.ComponentEditors;
 using SayMore.UI.ProjectWindow;
+using SIL.IO;
 
 namespace SayMore.UI.Overview
 {
@@ -109,15 +110,18 @@ namespace SayMore.UI.Overview
 
 			// make sure the directory exists
 			var dir = Path.Combine(Program.CurrentProject.FolderPath, FolderName);
-			if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+			if (!Directory.Exists(dir))
+				Directory.CreateDirectory(dir);
 
 			// copy the selected files to the directory
 			foreach (var file in files)
 			{
-				var fileName = (new FileInfo(file)).Name;
+				var fileName = Path.GetFileName(file);
 				var newFile = Path.Combine(dir, fileName);
 
 				// make sure the files don't already exist
+				if (file == newFile)
+					continue;
 				if (File.Exists(newFile))
 				{
 					var txt = LocalizationManager.GetString("CommonToMultipleViews.FileList.FileAlreadyExistsMessage",
@@ -129,7 +133,15 @@ namespace SayMore.UI.Overview
 				}
 
 				// copy the file
-				File.Copy(file, newFile, true);
+				try
+				{
+					RobustFile.Copy(file, newFile, true);
+				}
+				catch (Exception e)
+				{
+					Console.WriteLine(e);
+					ErrorReport.ReportNonFatalException(e);
+				}
 			}
 
 			_descriptionFileGrid.UpdateComponentFileList(GetFiles());

--- a/src/SayMore/UI/ProjectWindow/ProjectWindow.cs
+++ b/src/SayMore/UI/ProjectWindow/ProjectWindow.cs
@@ -316,6 +316,7 @@ namespace SayMore.UI.ProjectWindow
 					return;
 
 				Settings.Default.UserInterfaceLanguage = dlg.UILanguage;
+				Logger.WriteEvent("Changed UI Locale to: " + Settings.Default.UserInterfaceLanguage);
 				LocalizationManager.SetUILanguage(dlg.UILanguage, true);
 			}
 		}


### PR DESCRIPTION
Also prevented crash caused by trying to copy a file over itself and made program more robust by reporting other file copy errors instead of crashing.
Added lines to log file to be able to know which UI locale is in use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/138)
<!-- Reviewable:end -->
