### PR TITLE
SP-995, SP-2186, SP-2144: Fixed various scenarios leading to "Operation did not succeed"

### DIFF
--- a/DistFiles/SayMore.es.tmx
+++ b/DistFiles/SayMore.es.tmx
@@ -55,7 +55,7 @@
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.BindingHelper.AmbiguousDateNote">
-      <note>Text appended to the note for an element with an ambigous date field value</note>
+      <note>Text appended to the note for an element with an ambiguous date field value</note>
       <tuv xml:lang="en">
         <seg>***This record had an ambiguous {0}, produced by a bug in an old version of SayMore. The date was "{1}". SayMore has attempted to interpret the date, but might have swapped the day and month. Please accept our apologies for this error. After you have fixed the date or confirmed that it is correct, please delete this message.</seg>
       </tuv>

--- a/DistFiles/SayMore.fr.tmx
+++ b/DistFiles/SayMore.fr.tmx
@@ -63,7 +63,7 @@
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.BindingHelper.AmbiguousDateNote">
-      <note>Text appended to the note for an element with an ambigous date field value</note>
+      <note>Text appended to the note for an element with an ambiguous date field value</note>
       <tuv xml:lang="en">
         <seg>***This record had an ambiguous {0}, produced by a bug in an old version of SayMore. The date was "{1}". SayMore has attempted to interpret the date, but might have swapped the day and month. Please accept our apologies for this error. After you have fixed the date or confirmed that it is correct, please delete this message.</seg>
       </tuv>

--- a/DistFiles/SayMore.pt.tmx
+++ b/DistFiles/SayMore.pt.tmx
@@ -63,7 +63,7 @@
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.BindingHelper.AmbiguousDateNote">
-      <note>Text appended to the note for an element with an ambigous date field value</note>
+      <note>Text appended to the note for an element with an ambiguous date field value</note>
       <tuv xml:lang="en">
         <seg>***This record had an ambiguous {0}, produced by a bug in an old version of SayMore. The date was "{1}". SayMore has attempted to interpret the date, but might have swapped the day and month. Please accept our apologies for this error. After you have fixed the date or confirmed that it is correct, please delete this message.</seg>
       </tuv>

--- a/DistFiles/SayMore.ru.tmx
+++ b/DistFiles/SayMore.ru.tmx
@@ -63,7 +63,7 @@
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.BindingHelper.AmbiguousDateNote">
-      <note>Text appended to the note for an element with an ambigous date field value</note>
+      <note>Text appended to the note for an element with an ambiguous date field value</note>
       <tuv xml:lang="en">
         <seg>***This record had an ambiguous {0}, produced by a bug in an old version of SayMore. The date was "{1}". SayMore has attempted to interpret the date, but might have swapped the day and month. Please accept our apologies for this error. After you have fixed the date or confirmed that it is correct, please delete this message.</seg>
       </tuv>

--- a/DistFiles/SayMore.tr.tmx
+++ b/DistFiles/SayMore.tr.tmx
@@ -87,7 +87,7 @@
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.BindingHelper.AmbiguousDateNote">
-      <note>Text appended to the note for an element with an ambigous date field value</note>
+      <note>Text appended to the note for an element with an ambiguous date field value</note>
       <tuv xml:lang="en">
         <seg>***This record had an ambiguous {0}, produced by a bug in an old version of SayMore. The date was "{1}". SayMore has attempted to interpret the date, but might have swapped the day and month. Please accept our apologies for this error. After you have fixed the date or confirmed that it is correct, please delete this message.</seg>
       </tuv>

--- a/DistFiles/SayMore.zh-Hans.tmx
+++ b/DistFiles/SayMore.zh-Hans.tmx
@@ -39,7 +39,7 @@
       </tuv>
     </tu>
     <tu tuid="CommonToMultipleViews.BindingHelper.AmbiguousDateNote">
-      <note>Text appended to the note for an element with an ambigous date field value</note>
+      <note>Text appended to the note for an element with an ambiguous date field value</note>
       <tuv xml:lang="en">
         <seg>***This record had an ambiguous {0}, produced by a bug in an old version of SayMore. The date was "{1}". SayMore has attempted to interpret the date, but might have swapped the day and month. Please accept our apologies for this error. After you have fixed the date or confirmed that it is correct, please delete this message.</seg>
       </tuv>

--- a/SayMore.sln.DotSettings
+++ b/SayMore.sln.DotSettings
@@ -1,5 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=reentrant/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IMDI/@EntryIndexedValue">IMDI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Segmenter/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=toolstrip/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unrounded/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SayMore/UI/ComponentEditors/SessionBasicEditor.cs
+++ b/src/SayMore/UI/ComponentEditors/SessionBasicEditor.cs
@@ -631,13 +631,40 @@ namespace SayMore.UI.ComponentEditors
 			if (frm == null)
 				return;
 
-			var tabPages = ((ElementListScreen.ElementListScreen<Session>)frm.ActiveControl).SelectedComponentEditorsTabControl.TabPages;
-			foreach (TabPage tab in tabPages)
+			// The Contributors tab is the correct place to edit the people info, so we want
+			// to switch to that tab, but only if everything validates on this tab. This
+			// code plus the two methods it sets up to handle things keeps us from switching
+			// tabs and reporting the validation error twice if validation fails.
+			_participants.GotFocus += SwitchToContributorsTab;
+			_binder.ValidationFailed += AbortSwitchToContributorsBecauseValidationFailed;
+		}
+
+		private void AbortSwitchToContributorsBecauseValidationFailed(BindingHelper sender,
+			Control controlThatFailedValidation)
+		{
+			_participants.GotFocus -= SwitchToContributorsTab;
+		}
+
+		private void SwitchToContributorsTab(object sender, EventArgs e)
+		{
+			_participants.GotFocus -= SwitchToContributorsTab;
+
+			var frm = FindForm();
+			if (frm == null)
+				return;
+
+			var sessionEditorTabControl =
+				((ElementListScreen.ElementListScreen<Session>)frm.ActiveControl)
+				.SelectedComponentEditorsTabControl;
+
+			foreach (TabPage tab in sessionEditorTabControl.TabPages)
 			{
-				if (tab.ImageKey != @"Contributor") continue;
-				((ElementListScreen.ElementListScreen<Session>)frm.ActiveControl).SelectedComponentEditorsTabControl.SelectedTab = tab;
-				tab.Focus();
-				break;
+				if (tab.ImageKey == @"Contributor")
+				{
+					sessionEditorTabControl.SelectedTab = tab;
+					tab.Focus();
+					break;
+				}
 			}
 		}
 	}

--- a/src/SayMore/UI/ElementListScreen/ComponentFileGrid.cs
+++ b/src/SayMore/UI/ElementListScreen/ComponentFileGrid.cs
@@ -583,6 +583,9 @@ namespace SayMore.UI.ElementListScreen
 		/// ------------------------------------------------------------------------------------
 		private void HandleConvertButtonClick(object sender, EventArgs e)
 		{
+			if (!GetIsOKToPerformFileOperation())
+				return;
+
 			var index = _grid.CurrentCellAddress.Y;
 			var file = (index >= 0 && index < _files.Count() ? _files.ElementAt(index) : null);
 

--- a/src/SayMore/UI/ElementListScreen/ElementGrid.cs
+++ b/src/SayMore/UI/ElementListScreen/ElementGrid.cs
@@ -10,7 +10,6 @@ using SIL.Extensions;
 using SIL.Windows.Forms.Widgets.BetterGrid;
 using SayMore.Model;
 using SayMore.Model.Files;
-using SIL.Reporting;
 using SIL.Windows.Forms;
 
 namespace SayMore.UI.ElementListScreen
@@ -273,7 +272,7 @@ namespace SayMore.UI.ElementListScreen
 		{
 			base.OnCellMouseDown(e);
 
-			if (e.Button != MouseButtons.Right || e.RowIndex < 0)
+			if (e.Button != MouseButtons.Right || e.RowIndex < 0 || !IsOKToSelectDifferentElement())
 				return;
 
 			if (e.RowIndex != CurrentCellAddress.Y)

--- a/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
+++ b/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
@@ -399,7 +399,8 @@ namespace SayMore.UI.ElementListScreen
 		/// ------------------------------------------------------------------------------------
 		protected virtual void HandleAddingNewElement(object sender, EventArgs e)
 		{
-			AfterNewItemAdded(_model.CreateNewElement());
+			if (_elementsGrid.IsOKToSelectDifferentElement())
+				AfterNewItemAdded(_model.CreateNewElement());
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
+++ b/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;

--- a/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
+++ b/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
@@ -158,7 +158,7 @@ namespace SayMore.UI.ElementListScreen
 		/// Called by the component file grid when the user chooses a different file
 		/// </summary>
 		/// review: why use index, why not the object?
-		/// Answser: If the object is used, the caller of this delegate would have to get the object
+		/// Answer: If the object is used, the caller of this delegate would have to get the object
 		/// this way: _model.GetComponentFile(index). Using the index here is really just
 		/// passing off to the model the inevitable job of indexing into the component file list.
 		/// The grid (i.e. the only object calling this delegate so far) does not keep a

--- a/src/SayMore/UI/ElementListScreen/SessionsListScreen.cs
+++ b/src/SayMore/UI/ElementListScreen/SessionsListScreen.cs
@@ -181,6 +181,9 @@ namespace SayMore.UI.ElementListScreen
 		/// ------------------------------------------------------------------------------------
 		private void HandleButtonNewFromFilesClick(object sender, EventArgs e)
 		{
+			if (!_elementsGrid.IsOKToSelectDifferentElement())
+				return;
+
 			using (var viewModel = _newSessionsFromFileDlgViewModel(_model))
 			using (var dlg = new NewSessionsFromFilesDlg(viewModel))
 			{
@@ -194,7 +197,7 @@ namespace SayMore.UI.ElementListScreen
 		/// ------------------------------------------------------------------------------------
 		private void HandleButtonNewFromRecordingsClick(object sender, EventArgs e)
 		{
-			if (!AudioUtils.GetCanRecordAudio())
+			if (!_elementsGrid.IsOKToSelectDifferentElement() || !AudioUtils.GetCanRecordAudio())
 				return;
 
 			using (var viewModel = new SessionRecorderDlgViewModel())

--- a/src/SayMore/UI/LowLevelControls/ListPanel.cs
+++ b/src/SayMore/UI/LowLevelControls/ListPanel.cs
@@ -153,22 +153,7 @@ namespace SayMore.UI.LowLevelControls
 
 		/// ------------------------------------------------------------------------------------
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public Button NewButton
-		{
-			get { return _buttonNew; }
-		}
-
-		/// ------------------------------------------------------------------------------------
-		/// <summary>
-		/// Call delete handler delegates and remove the selected items if the delegate
-		/// returns true.
-		/// </summary>
-		/// ------------------------------------------------------------------------------------
-		private void HandleDeleteButtonClick(object sender, EventArgs e)
-		{
-			if (DeleteButtonClicked != null)
-				DeleteButtonClicked(sender, e);
-		}
+		public Button NewButton => _buttonNew;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -177,8 +162,7 @@ namespace SayMore.UI.LowLevelControls
 		/// ------------------------------------------------------------------------------------
 		private void HandleNewButtonClick(object sender, EventArgs e)
 		{
-			if (NewButtonClicked != null)
-				NewButtonClicked(this, e);
+			NewButtonClicked?.Invoke(this, e);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/src/SayMore/UI/ProjectWindow/ViewButtonManager.cs
+++ b/src/SayMore/UI/ProjectWindow/ViewButtonManager.cs
@@ -128,21 +128,19 @@ namespace SayMore.UI.ProjectWindow
 			if (btn == currbtn)
 				return;
 
-			var newVw = (btn == null ? null : _controls[btn]);
+			var newVw = _controls[btn];
 
 			// Now make sure we can leave the current view.
 			foreach (var vw in Views)
 			{
-				var ctrl = vw as Control;
-				if (ctrl != null && !ctrl.IsHandleCreated)
+				if (vw is Control ctrl && !ctrl.IsHandleCreated)
 					continue;
 
 				if (vw != newVw && !vw.IsOKToLeaveView(true))
 					return;
 			}
 
-			if (_toolStripOwner != null)
-				_toolStripOwner.SetWindowRedraw(false);
+			_toolStripOwner?.SetWindowRedraw(false);
 
 			if (currbtn != null && _controls.ContainsKey(currbtn))
 			{
@@ -153,19 +151,16 @@ namespace SayMore.UI.ProjectWindow
 					((ISayMoreView)_controls[currbtn]).ViewDeactivated();
 			}
 
-			if (btn != null)
-			{
-				btn.Checked = true;
-				newVw.Visible = true;
-				newVw.BringToFront();
-			}
+			btn.Checked = true;
+			newVw.Visible = true;
+			newVw.BringToFront();
 
 			if (_toolStripOwner != null)
 				_toolStripOwner.SetWindowRedraw(true);
 
-			if (newVw is ISayMoreView)
+			if (newVw is ISayMoreView sayMoreView)
 			{
-				((ISayMoreView)newVw).ViewActivated(!_hasBeenActivatedList[newVw]);
+				sayMoreView.ViewActivated(!_hasBeenActivatedList[newVw]);
 				_hasBeenActivatedList[newVw] = true;
 			}
 		}


### PR DESCRIPTION
Despite validation errors, SayMore would allow the user to go ahead with changing to a different view, task, etc. that would lead to an exception: Operation did not succeed because the program cannot commit or quit a cell value change.

Note that I was not able to reproduce SP-2186/SP-2265 in the current version, but I did determine that the previous fix for SP-2186 was actually for a different scenario that caused the same exception. I suspect that some subsequent change actually fixed the problem, but even if not, it's possible that this fix will.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/144)
<!-- Reviewable:end -->
