### PR TITLE
SP-1760: Added defensive code to prevent argument out of range error

### DIFF
--- a/src/SayMore/UI/ElementListScreen/ComponentFileGrid.cs
+++ b/src/SayMore/UI/ElementListScreen/ComponentFileGrid.cs
@@ -394,7 +394,7 @@ namespace SayMore.UI.ElementListScreen
 		/// ------------------------------------------------------------------------------------
 		protected virtual void HandleFileGridCellValueNeeded(object sender, DataGridViewCellValueEventArgs e)
 		{
-			if (e.ColumnIndex < 0 || e.ColumnIndex >= _grid.ColumnCount || e.RowIndex < 0 || e.RowIndex >= _files.Count())
+			if (e.ColumnIndex < 0 || e.ColumnIndex >= _grid.ColumnCount || e.RowIndex < 0 || e.RowIndex >= _files.Count)
 				return;
 			var propName = _grid.Columns[e.ColumnIndex].DataPropertyName;
 			var currFile = _files.ElementAt(e.RowIndex);
@@ -470,8 +470,12 @@ namespace SayMore.UI.ElementListScreen
 		{
 			if (fileToSelectAfterUpdate == null)
 			{
-				fileToSelectAfterUpdate = (_grid.CurrentCellAddress.Y >= 0 && _files.Any() ?
-					_files.ElementAt(_grid.CurrentCellAddress.Y) : null);
+				// SP-1760: If the user deletes files in explorer that are being shown in the
+				// component file list, it's possible for the current row to suddenly go out of
+				// range.
+				fileToSelectAfterUpdate =
+					_grid.CurrentCellAddress.Y >= 0 && _files.Count > _grid.CurrentCellAddress.Y ?
+					_files.ElementAt(_grid.CurrentCellAddress.Y) : null;
 			}
 
 			_files = componentFiles;


### PR DESCRIPTION
Although I was not able to reproduce this error (it is several years old, and possibly some other fix now makes it impossible), it seemed best to check the index rather than blindly accessing a potentially nonexistent element merely for the sake of being able to re-select it later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/145)
<!-- Reviewable:end -->
