### PR TITLE
SP-1769: Prevent changing the grid while executing PlaybackProgressReportAction

### DIFF
--- a/src/SayMore/Transcription/UI/TextAnnotationGrid/AudioWaveFormColumn.cs
+++ b/src/SayMore/Transcription/UI/TextAnnotationGrid/AudioWaveFormColumn.cs
@@ -46,12 +46,15 @@ namespace SayMore.Transcription.UI
 			_grid.PreProcessMouseClick += HandleGridPreProcessMouseClick;
 			_grid.SetPlaybackProgressReportAction(() =>
 			{
-				// SP-2214/SP-2218/SP-2221/SP-2225/SP-2226
-				// Although I could not figure out how to reproduce this, this is certainly the fix.
-				// At worst (unlikely), it could result in some kind of display issue, but it will
-				// avoid the crash.
-				if (_grid.CurrentCellAddress != null)
-					_grid.InvalidateCell(Index, _grid.CurrentCellAddress.Y);
+				lock (this)
+				{
+					// SP-1769/SP-2214/SP-2218/SP-2221/SP-2225/SP-2226
+					// Although I could not figure out how to reproduce this, this is certainly the fix.
+					// At worst (unlikely), it could result in some kind of display issue, but it will
+					// avoid the crash.
+					if (_grid?.CurrentCellAddress != null)
+						_grid.InvalidateCell(Index, _grid.CurrentCellAddress.Y);
+				}
 			});
 
 			//_grid.PlaybackSpeedChanged += HandlePlaybackSpeedChanged;

--- a/src/SayMore/Transcription/UI/TextAnnotationGrid/TierColumnBase.cs
+++ b/src/SayMore/Transcription/UI/TextAnnotationGrid/TierColumnBase.cs
@@ -48,7 +48,8 @@ namespace SayMore.Transcription.UI
 			if (_grid != null)
 				UnsubscribeToGridEvents();
 
-			_grid = DataGridView as TextAnnotationEditorGrid;
+			lock (this) // SP-1769: Don't change this while executing the PlaybackProgressReportAction
+				_grid = DataGridView as TextAnnotationEditorGrid;
 
 			if (_grid != null)
 				SubscribeToGridEvents();


### PR DESCRIPTION
Also check for a null grid before accessing it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/156)
<!-- Reviewable:end -->
