### PR TITLE
Fixed problem with logger for media playback

### DIFF
--- a/src/SayMore/MediaUtils/MPlayer/MPlayerHelper.cs
+++ b/src/SayMore/MediaUtils/MPlayer/MPlayerHelper.cs
@@ -274,7 +274,7 @@ namespace SayMore.Media.MPlayer
 
 	#region MPlayerOutputLogForm class
 	/// ------------------------------------------------------------------------------------
-	public class MPlayerOutputLogForm : Form
+	public class MPlayerOutputLogForm : Form, ILogger
 	{
 		private readonly TextBox _textBox;
 
@@ -314,16 +314,27 @@ namespace SayMore.Media.MPlayer
 		/// --------------------------------------------------------------------------------
 		public void UpdateLogDisplay(string output)
 		{
-			Invoke((Action)(() => _textBox.SelectionStart = _textBox.Text.Length));
-			Invoke((Action<string>)(text => _textBox.SelectedText = text + Environment.NewLine), output);
-		}
+			Invoke((Action)(() => {
+                _textBox.SelectionStart = _textBox.Text.Length;
+                _textBox.SelectedText = output + Environment.NewLine;
+            }));
+        }
 
 		/// --------------------------------------------------------------------------------
-		protected override bool ShowWithoutActivation
-		{
-			get { return true; }
-		}
-	}
+		protected override bool ShowWithoutActivation => true;
+
+        public string GetText()
+        {
+            string result = null;
+            Invoke((Action)(() => result = _textBox.Text));
+            return result;
+        }
+
+        public void AddText(string text)
+        {
+            UpdateLogDisplay(text);
+        }
+    }
 
 	#endregion
 }

--- a/src/SayMore/MediaUtils/MPlayer/MediaPlayer.cs
+++ b/src/SayMore/MediaUtils/MPlayer/MediaPlayer.cs
@@ -47,7 +47,7 @@ namespace SayMore.Media.MPlayer
 			_viewModel.PlaybackStarted += HandleMediaPlayStarted;
 			_viewModel.PlaybackPaused = delegate { Invoke((Action)HandlePlaybackPausedResumed); };
 			_viewModel.PlaybackResumed = delegate { Invoke((Action)HandlePlaybackPausedResumed); };
-			_viewModel.PlaybackPositionChanged = delegate(float pos) { Invoke((Action<float>)(HandlePlaybackPositionChanged), pos); };
+			_viewModel.PlaybackPositionChanged = ViewModelPlaybackPositionChanged;
 
 			UpdateButtons();
 			_volumePopup.VolumeLevel = _viewModel.Volume;
@@ -55,7 +55,19 @@ namespace SayMore.Media.MPlayer
 			_videoPanel.SetPlayerViewModel(_viewModel);
 		}
 
-		/// ------------------------------------------------------------------------------------
+        private void ViewModelPlaybackPositionChanged(float pos)
+        {
+            try
+            {
+                Invoke((Action<float>)(HandlePlaybackPositionChanged), pos);
+            }
+            catch (InvalidAsynchronousStateException e)
+            {
+                Logger.WriteError(e);
+            }
+        }
+
+        /// ------------------------------------------------------------------------------------
 		private void SetupVolumePopup()
 		{
 			_videoPanel.Controls.Remove(_volumePopup);

--- a/src/SayMore/Transcription/UI/ComponentEditors/ConvertToStandardAudioEditor.cs
+++ b/src/SayMore/Transcription/UI/ComponentEditors/ConvertToStandardAudioEditor.cs
@@ -25,7 +25,7 @@ namespace SayMore.Transcription.UI
 			Name = "StartAnnotating";
 
 			_tableLayoutConvert.Dock = DockStyle.Top;
-			// ENHANCE: I made the Dispose method for this class disposes of the Image. However,
+			// ENHANCE: I made the Dispose method for this class dispose of the Image. However,
 			// Dispose !never! gets called. This is not a huge bitmap, of course, but this
 			// constructor can get called quite a few times. It gets squirreled away in the _editors
 			// hashtable in FileType using a cryptic hashcode from ElementListViewModel. But FileType


### PR DESCRIPTION
Added code to catch InvalidAsynchronousStateException during media playback which I think is happening when trying to invoke on the UI thread during a shutdown or crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/166)
<!-- Reviewable:end -->
