### PR TITLE
Added option to import Audacity labels into free translation

### DIFF
--- a/DistFiles/SayMore.es.xlf
+++ b/DistFiles/SayMore.es.xlf
@@ -4,4802 +4,4868 @@
     <body>
       <trans-unit id="BuildType.Alpha">
         <source xml:lang="en">Alpha</source>
-        <note>ID: BuildType.Alpha</note>
         <target xml:lang="es-ES" state="translated">Alfa</target>
+        <note>ID: BuildType.Alpha</note>
       </trans-unit>
       <trans-unit id="BuildType.Beta">
         <source xml:lang="en">Beta</source>
-        <note>ID: BuildType.Beta</note>
         <target xml:lang="es-ES" state="translated">Beta</target>
+        <note>ID: BuildType.Beta</note>
       </trans-unit>
       <trans-unit id="BuildType.ReleaseCandidate">
         <source xml:lang="en">Release Candidate</source>
-        <note>ID: BuildType.ReleaseCandidate</note>
         <target xml:lang="es-ES" state="needs-translation">Release Candidate</target>
+        <note>ID: BuildType.ReleaseCandidate</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.AllFilesDescriptor">
         <source xml:lang="en">All Files ({0})</source>
-        <note>ID: CommonToMultipleViews.AllFilesDescriptor</note>
         <target xml:lang="es-ES" state="translated">Todos los archivos ({0})</target>
+        <note>ID: CommonToMultipleViews.AllFilesDescriptor</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.AttemptedRetriesMsg">
         <source xml:lang="en">(Retries attempted: {0})</source>
-        <note>ID: CommonToMultipleViews.AttemptedRetriesMsg</note>
-        <note>Parameter is the number of times SayMore has attempted to move the temp file to the permanent location.</note>
         <target xml:lang="es-ES" state="translated">(Reintentos: {0})</target>
+        <note>ID: CommonToMultipleViews.AttemptedRetriesMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.AudioUtils.NoPlaybackDevicesFoundMsg">
         <source xml:lang="en">Currently SayMore is unable to find any audio playback devices installed and enabled on this computer.</source>
-        <note>ID: CommonToMultipleViews.AudioUtils.NoPlaybackDevicesFoundMsg</note>
         <target xml:lang="es-ES" state="translated">Actualmente SayMore es incapaz de encontrar un dispositivo de reproducción de audio instalado y habilitado en esta computadora.</target>
+        <note>ID: CommonToMultipleViews.AudioUtils.NoPlaybackDevicesFoundMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.AudioUtils.NoRecordingDevicesFoundMsg">
         <source xml:lang="en">Currently audio recordings cannot be made because SayMore is unable to find any recording devices installed and enabled on this computer.</source>
-        <note>ID: CommonToMultipleViews.AudioUtils.NoRecordingDevicesFoundMsg</note>
         <target xml:lang="es-ES" state="translated">Actualmente no se puede grabar audio porque SayMore no encuentra un dispositivo de grabación instalado y habilitado en esta computadora.</target>
+        <note>ID: CommonToMultipleViews.AudioUtils.NoRecordingDevicesFoundMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.AudioUtils.UnexpectedAudioErrorMsg">
         <source xml:lang="en">There was an unexpected audio error.</source>
-        <note>ID: CommonToMultipleViews.AudioUtils.UnexpectedAudioErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Hubo un error de audio inesperado.</target>
+        <note>ID: CommonToMultipleViews.AudioUtils.UnexpectedAudioErrorMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.BindingHelper.AmbiguousDateNote">
         <source xml:lang="en">***This record had an ambiguous {0}, produced by a bug in an old version of SayMore. The date was "{1}". SayMore has attempted to interpret the date, but might have swapped the day and month. Please accept our apologies for this error. After you have fixed the date or confirmed that it is correct, please delete this message.</source>
-        <note>ID: CommonToMultipleViews.BindingHelper.AmbiguousDateNote</note>
-        <note>Text appended to the note for an element with an ambiguous date field value</note>
         <target xml:lang="es-ES" state="translated">*** Este record tuvo una ambigua {0}, producida por un error en una versión previa de SayMore. La fecha grabada era "{1}". SayMore ha intentado interpretar la fecha, pero posiblemente ha intercambiado el día y mes. Por favor, acepte nuestras disculpas por este error. Después de corregir la fecha o confirmar que es correcta, por favor borre esta nota.</target>
+        <note>ID: CommonToMultipleViews.BindingHelper.AmbiguousDateNote</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ChangeIdDotDash">
         <source xml:lang="en">To avoid possible conflicts with files created by Mac OSX, names cannot begin with "{0}".</source>
-        <note>ID: CommonToMultipleViews.ChangeIdDotDash</note>
-        <note>Param is the literal string "._"</note>
         <target xml:lang="es-ES" state="translated">Para evitar conflictos potenciales con archivos creados por Mac OSX, los nombres no pueden comenzar con "{0}".</target>
+        <note>ID: CommonToMultipleViews.ChangeIdDotDash</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ChangeIdFailureMsg">
         <source xml:lang="en">Something is holding onto that folder or a file in it, so it cannot be renamed. You can try restarting this program, or restarting the computer.</source>
-        <note>ID: CommonToMultipleViews.ChangeIdFailureMsg</note>
-        <note>Message displayed when attempt failed to change a session id or a person's name (i.e. id)</note>
         <target xml:lang="es-ES" state="translated">Un programa está accesando esa carpeta o uno de los archivos que ella contiene, por lo que no se puede cambiar el nombre. Intente reiniciar este programa, o reiniciar el equipo.</target>
+        <note>ID: CommonToMultipleViews.ChangeIdFailureMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ContributorsEditor.MissingContributorNameMsg">
         <source xml:lang="en">Enter a name.</source>
-        <note>ID: CommonToMultipleViews.ContributorsEditor.MissingContributorNameMsg</note>
         <target xml:lang="es-ES" state="translated">Introduzca un nombre.</target>
+        <note>ID: CommonToMultipleViews.ContributorsEditor.MissingContributorNameMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ContributorsEditor.MissingContributorRoleMsg">
         <source xml:lang="en">Choose a role.</source>
-        <note>ID: CommonToMultipleViews.ContributorsEditor.MissingContributorRoleMsg</note>
         <target xml:lang="es-ES" state="translated">Elija un papel.</target>
+        <note>ID: CommonToMultipleViews.ContributorsEditor.MissingContributorRoleMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ContributorsEditor.TabText">
         <source xml:lang="en">Contributors</source>
-        <note>ID: CommonToMultipleViews.ContributorsEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Colaboradores</target>
+        <note>ID: CommonToMultipleViews.ContributorsEditor.TabText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ElementList.ColumnChooserButton_ToolTip_">
         <source xml:lang="en">Choose Columns</source>
-        <note>ID: CommonToMultipleViews.ElementList.ColumnChooserButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Elegir columnas</target>
+        <note>ID: CommonToMultipleViews.ElementList.ColumnChooserButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ElementList.NewButtonText">
         <source xml:lang="en">&amp;New</source>
-        <note>ID: CommonToMultipleViews.ElementList.NewButtonText</note>
-        <note>Button for adding new sessions and people</note>
         <target xml:lang="es-ES" state="translated">&amp;Añadir</target>
+        <note>ID: CommonToMultipleViews.ElementList.NewButtonText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ElementList.OneColumnMustBeVisibleMsg">
         <source xml:lang="en">One column must be visible.</source>
-        <note>ID: CommonToMultipleViews.ElementList.OneColumnMustBeVisibleMsg</note>
-        <note>Displayed when user clears all columns for display in sessions or people list</note>
         <target xml:lang="es-ES" state="translated">Al menos una columna debe ser visible.</target>
+        <note>ID: CommonToMultipleViews.ElementList.OneColumnMustBeVisibleMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.ColumnHeadings.Field">
         <source xml:lang="en">Field</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.ColumnHeadings.Field</note>
         <target xml:lang="es-ES" state="translated">Campo</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.ColumnHeadings.Field</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.ColumnHeadings.Value">
         <source xml:lang="en">Value</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.ColumnHeadings.Value</note>
         <target xml:lang="es-ES" state="translated">Valor</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.ColumnHeadings.Value</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.AudioBitRate">
         <source xml:lang="en">Audio Bit Rate</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.AudioBitRate</note>
         <target xml:lang="es-ES" state="translated">Velocidad de bits de audio</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.AudioBitRate</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.BitDepth">
         <source xml:lang="en">Bit Depth</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.BitDepth</note>
         <target xml:lang="es-ES" state="translated">Profundidad de bits</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.BitDepth</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Channels">
         <source xml:lang="en">Channels</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Channels</note>
         <target xml:lang="es-ES" state="translated">Canales</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Channels</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Device">
         <source xml:lang="en">Device</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Device</note>
         <target xml:lang="es-ES" state="translated">Dispositivo</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Device</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Duration">
         <source xml:lang="en">Duration</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Duration</note>
         <target xml:lang="es-ES" state="translated">Duración</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Duration</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.FrameRate">
         <source xml:lang="en">Frame Rate</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.FrameRate</note>
         <target xml:lang="es-ES" state="translated">Velocidad de fotogramas</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.FrameRate</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Microphone">
         <source xml:lang="en">Microphone</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Microphone</note>
         <target xml:lang="es-ES" state="translated">Micrófono</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Microphone</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Resolution">
         <source xml:lang="en">Resolution</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Resolution</note>
         <target xml:lang="es-ES" state="translated">Resolución</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.Resolution</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.SampleRate">
         <source xml:lang="en">Sample Rate</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.SampleRate</note>
         <target xml:lang="es-ES" state="translated">Velocidad de muestreo</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.SampleRate</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.VideoBitRate">
         <source xml:lang="en">Video Bit Rate</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.VideoBitRate</note>
         <target xml:lang="es-ES" state="translated">Tasa de bits de vídeo</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.MediaPropertyNames.VideoBitRate</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FieldsAndValuesGrid.VerifyDeleteFieldQuestion">
         <source xml:lang="en">Do you want to delete the field '{0}' and its contents from the entire project?</source>
-        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.VerifyDeleteFieldQuestion</note>
         <target xml:lang="es-ES" state="translated">¿Desea eliminar el campo '{0}' y su contenido en cada record del proyecto?</target>
+        <note>ID: CommonToMultipleViews.FieldsAndValuesGrid.VerifyDeleteFieldQuestion</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileIsReadOnly">
         <source xml:lang="en">SayMore is not able to write to the file "{0}." It is read-only.</source>
-        <note>ID: CommonToMultipleViews.FileIsReadOnly</note>
         <target xml:lang="es-ES" state="translated">SayMore no puede grabar el archivo "{0}." Es de sólo lectura.</target>
+        <note>ID: CommonToMultipleViews.FileIsReadOnly</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileIsReadOnlyOrLocked">
         <source xml:lang="en">SayMore is not able to write to the file "{0}." It is read-only or locked.</source>
-        <note>ID: CommonToMultipleViews.FileIsReadOnlyOrLocked</note>
         <target xml:lang="es-ES" state="translated">SayMore no puede grabar el archivo "{0}." Es de sólo lectura o está bloqueado.</target>
+        <note>ID: CommonToMultipleViews.FileIsReadOnlyOrLocked</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.FileList.AddFiles.CannotAddFilesOfElementType">
+        <source xml:lang="en">Additional {0} files cannot be added to an existing {0}.</source>
+        <target xml:lang="es-ES" state="translated">Archivos adicionales de tipo {0} no pueden ser añadidos a una {0} existente.</target>
+        <note>ID: CommonToMultipleViews.FileList.AddFiles.CannotAddFilesOfElementType</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.AddFiles.OpenFileDlg.Caption">
         <source xml:lang="en">Add Files</source>
-        <note>ID: CommonToMultipleViews.FileList.AddFiles.OpenFileDlg.Caption</note>
         <target xml:lang="es-ES" state="translated">Agregar archivos</target>
+        <note>ID: CommonToMultipleViews.FileList.AddFiles.OpenFileDlg.Caption</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.AddFiles.OpenFileDlg.FileTypeString">
         <source xml:lang="en">All Files (*.*)</source>
-        <note>ID: CommonToMultipleViews.FileList.AddFiles.OpenFileDlg.FileTypeString</note>
         <target xml:lang="es-ES" state="translated">todos los archivos (*.*)</target>
+        <note>ID: CommonToMultipleViews.FileList.AddFiles.OpenFileDlg.FileTypeString</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.AddFilesButtonText">
         <source xml:lang="en">Add Files...</source>
-        <note>ID: CommonToMultipleViews.FileList.AddFilesButtonText</note>
         <target xml:lang="es-ES" state="translated">Agregar archivos...</target>
+        <note>ID: CommonToMultipleViews.FileList.AddFilesButtonText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.AddFilesPrompt">
         <source xml:lang="en">Add additional files related to this session by\ndragging them here or clicking the 'Add Files' button.</source>
-        <note>ID: CommonToMultipleViews.FileList.AddFilesPrompt</note>
         <target xml:lang="es-ES" state="translated">Agregue archivos adicionales relacionados con esta sesión\narrastrándolos aquí o haciendo clic en el botón 'Agregar archivos'.</target>
+        <note>ID: CommonToMultipleViews.FileList.AddFilesPrompt</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.CannotOpenFileInApplicationErrorMsg">
         <source xml:lang="en">There was a problem opening the file\n\n'{0}'\n\nMake sure there is an application associated with this type of file.</source>
-        <note>ID: CommonToMultipleViews.FileList.CannotOpenFileInApplicationErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Hubo un problema al abrir el file\n\n'{0}'\n\nAsegúrese de que hay una aplicación asociada con este tipo de archivo.</target>
+        <note>ID: CommonToMultipleViews.FileList.CannotOpenFileInApplicationErrorMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.CannotRenameFileErrorMsg">
         <source xml:lang="en">{0} could not rename the file to '{1}' because there is already a file with that name.</source>
-        <note>ID: CommonToMultipleViews.FileList.CannotRenameFileErrorMsg</note>
         <target xml:lang="es-ES" state="translated">{0} no pudo cambiar el nombre del archivo a '{1}' porque ya existe un archivo con ese nombre.</target>
+        <note>ID: CommonToMultipleViews.FileList.CannotRenameFileErrorMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.CannotRenameFileGenericErrorMsg">
         <source xml:lang="en">Sorry, SayMore could not rename that file because something else (perhaps another part of SayMore) is reading it. Please try again later.</source>
-        <note>ID: CommonToMultipleViews.FileList.CannotRenameFileGenericErrorMsg</note>
         <target xml:lang="es-ES" state="translated">SayMore no pudo cambiar el nombre que el archivo porque un programa (quizás otro componente de SayMore mismo) lo está accesando. Inténtalo de nuevo más tarde.</target>
+        <note>ID: CommonToMultipleViews.FileList.CannotRenameFileGenericErrorMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.CannotRenameMetadataFileErrorMsg">
         <source xml:lang="en">{0} could not rename the meta data file to '{1}' because there is already a file with that name.</source>
-        <note>ID: CommonToMultipleViews.FileList.CannotRenameMetadataFileErrorMsg</note>
         <target xml:lang="es-ES" state="translated">{0} no pudo cambiar el nombre del archivo de metadatos porque ya existe un archivo nombrado: '{1}'.</target>
+        <note>ID: CommonToMultipleViews.FileList.CannotRenameMetadataFileErrorMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.ColumnHeadings.FileDate">
         <source xml:lang="en">Date Modified</source>
-        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileDate</note>
         <target xml:lang="es-ES" state="translated">Fecha de modificación</target>
+        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileDate</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.ColumnHeadings.FileDuration">
         <source xml:lang="en">Duration</source>
-        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileDuration</note>
         <target xml:lang="es-ES" state="translated">Duración</target>
+        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileDuration</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.ColumnHeadings.FileName">
         <source xml:lang="en">Name</source>
-        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileName</note>
         <target xml:lang="es-ES" state="translated">Nombre</target>
+        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileName</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.ColumnHeadings.FileSize">
         <source xml:lang="en">Size</source>
-        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileSize</note>
         <target xml:lang="es-ES" state="translated">Tamaño</target>
+        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileSize</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.ColumnHeadings.FileType">
         <source xml:lang="en">Type</source>
-        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileType</note>
         <target xml:lang="es-ES" state="translated">Tipo</target>
+        <note>ID: CommonToMultipleViews.FileList.ColumnHeadings.FileType</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.Convert.ButtonText">
         <source xml:lang="en">Convert...</source>
-        <note>ID: CommonToMultipleViews.FileList.Convert.ButtonText</note>
         <target xml:lang="es-ES" state="translated">Convertir...</target>
+        <note>ID: CommonToMultipleViews.FileList.Convert.ButtonText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.Convert.ButtonText_ToolTip_">
         <source xml:lang="en">Convert Selected File</source>
-        <note>ID: CommonToMultipleViews.FileList.Convert.ButtonText_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Convertir archivo seleccionado</target>
+        <note>ID: CommonToMultipleViews.FileList.Convert.ButtonText_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.Convert.ConvertMenuText">
         <source xml:lang="en">Convert...</source>
-        <note>ID: CommonToMultipleViews.FileList.Convert.ConvertMenuText</note>
         <target xml:lang="es-ES" state="translated">Convertir...</target>
+        <note>ID: CommonToMultipleViews.FileList.Convert.ConvertMenuText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.Convert.ExtractMp3AudioMenuText">
         <source xml:lang="en">Extract audio to mono mp3 audio file (low quality)</source>
-        <note>ID: CommonToMultipleViews.FileList.Convert.ExtractMp3AudioMenuText</note>
         <target xml:lang="es-ES" state="translated">Extraer audio para grabar como mono MP3 (baja calidad)</target>
+        <note>ID: CommonToMultipleViews.FileList.Convert.ExtractMp3AudioMenuText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.DeleteFileMenuText">
         <source xml:lang="en">&amp;Delete File...</source>
-        <note>ID: CommonToMultipleViews.FileList.DeleteFileMenuText</note>
         <target xml:lang="es-ES" state="translated">&amp;Borrar archivo...</target>
+        <note>ID: CommonToMultipleViews.FileList.DeleteFileMenuText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.DeleteSubordinateFilesFormat">
         <source xml:lang="en">{0} and subordinate files</source>
-        <note>ID: CommonToMultipleViews.FileList.DeleteSubordinateFilesFormat</note>
-        <note>Used to format a string that will indicate that subordinate files (i.e., annotation files) will also be moved to the recycle bin. Parameter is the name (without path) of the main file being deleted.</note>
         <target xml:lang="es-ES" state="translated">{0} y archivos de anotación relacionados</target>
+        <note>ID: CommonToMultipleViews.FileList.DeleteSubordinateFilesFormat</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileAlreadyExistsMessage">
         <source xml:lang="en">There is already a file named {0} in this project. Do you want to replace the old one with this one?</source>
-        <note>ID: CommonToMultipleViews.FileList.FileAlreadyExistsMessage</note>
         <target xml:lang="es-ES" state="translated">Ya existe un archivo llamado {0} en este proyecto. ¿Desea reemplazarlo con éste?</target>
+        <note>ID: CommonToMultipleViews.FileList.FileAlreadyExistsMessage</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileSizeBytes">
         <source xml:lang="en">{0} Bytes</source>
-        <note>ID: CommonToMultipleViews.FileList.FileSizeBytes</note>
         <target xml:lang="es-ES" state="translated">{0} Bytes</target>
+        <note>ID: CommonToMultipleViews.FileList.FileSizeBytes</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileSizeBytesAbbreviation">
         <source xml:lang="en">{0} B</source>
-        <note>ID: CommonToMultipleViews.FileList.FileSizeBytesAbbreviation</note>
         <target xml:lang="es-ES" state="translated">{0} B</target>
+        <note>ID: CommonToMultipleViews.FileList.FileSizeBytesAbbreviation</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileSizeGigabytes">
         <source xml:lang="en">{0} Gigabytes</source>
-        <note>ID: CommonToMultipleViews.FileList.FileSizeGigabytes</note>
         <target xml:lang="es-ES" state="translated">{0} Gigabytes</target>
+        <note>ID: CommonToMultipleViews.FileList.FileSizeGigabytes</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileSizeGigabytesAbbreviation">
         <source xml:lang="en">{0} GB</source>
-        <note>ID: CommonToMultipleViews.FileList.FileSizeGigabytesAbbreviation</note>
         <target xml:lang="es-ES" state="translated">{0} GB</target>
+        <note>ID: CommonToMultipleViews.FileList.FileSizeGigabytesAbbreviation</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileSizeKilobytes">
         <source xml:lang="en">{0} Kilobytes</source>
-        <note>ID: CommonToMultipleViews.FileList.FileSizeKilobytes</note>
         <target xml:lang="es-ES" state="translated">{0} Kilobytes</target>
+        <note>ID: CommonToMultipleViews.FileList.FileSizeKilobytes</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileSizeKilobytesAbbreviation">
         <source xml:lang="en">{0} KB</source>
-        <note>ID: CommonToMultipleViews.FileList.FileSizeKilobytesAbbreviation</note>
         <target xml:lang="es-ES" state="translated">{0} KB</target>
+        <note>ID: CommonToMultipleViews.FileList.FileSizeKilobytesAbbreviation</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileSizeMegabytes">
         <source xml:lang="en">{0} Megabytes</source>
-        <note>ID: CommonToMultipleViews.FileList.FileSizeMegabytes</note>
         <target xml:lang="es-ES" state="translated">{0} Megabytes</target>
+        <note>ID: CommonToMultipleViews.FileList.FileSizeMegabytes</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.FileSizeMegabytesAbbreviation">
         <source xml:lang="en">{0} MB</source>
-        <note>ID: CommonToMultipleViews.FileList.FileSizeMegabytesAbbreviation</note>
         <target xml:lang="es-ES" state="translated">{0} MB</target>
+        <note>ID: CommonToMultipleViews.FileList.FileSizeMegabytesAbbreviation</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.Open.ButtonText">
         <source xml:lang="en">Open</source>
-        <note>ID: CommonToMultipleViews.FileList.Open.ButtonText</note>
         <target xml:lang="es-ES" state="translated">Abrir</target>
+        <note>ID: CommonToMultipleViews.FileList.Open.ButtonText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.Open.ButtonText_ToolTip_">
         <source xml:lang="en">Open Selected File</source>
-        <note>ID: CommonToMultipleViews.FileList.Open.ButtonText_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Abrir el archivo seleccionado</target>
+        <note>ID: CommonToMultipleViews.FileList.Open.ButtonText_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.Open.OpenInAssociatedProgramMenuText">
         <source xml:lang="en">Open in Program Associated with this File ...</source>
-        <note>ID: CommonToMultipleViews.FileList.Open.OpenInAssociatedProgramMenuText</note>
         <target xml:lang="es-ES" state="translated">Abrir con el programa asociado con este archivo...</target>
+        <note>ID: CommonToMultipleViews.FileList.Open.OpenInAssociatedProgramMenuText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.Open.ShowInFileExplorerMenuText">
         <source xml:lang="en">Show in File Explorer...</source>
-        <note>ID: CommonToMultipleViews.FileList.Open.ShowInFileExplorerMenuText</note>
         <target xml:lang="es-ES" state="translated">Mostrar en el explorador de archivos...</target>
+        <note>ID: CommonToMultipleViews.FileList.Open.ShowInFileExplorerMenuText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.RenameButtonText">
         <source xml:lang="en">Rename...</source>
-        <note>ID: CommonToMultipleViews.FileList.RenameButtonText</note>
         <target xml:lang="es-ES" state="translated">Cambiar el nombre...</target>
+        <note>ID: CommonToMultipleViews.FileList.RenameButtonText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.FileList.RenameButtonText_ToolTip_">
         <source xml:lang="en">Rename Selected File</source>
-        <note>ID: CommonToMultipleViews.FileList.RenameButtonText_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Cambiar el nombre de archivo seleccionado</target>
+        <note>ID: CommonToMultipleViews.FileList.RenameButtonText_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.GenericFileTypeViewer.FailedToLoadOtherFile">
         <source xml:lang="en">Failed to load file:\n{0}\nIf this is not an essential file, you can safely delete it and/or ignore this error.</source>
-        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FailedToLoadOtherFile</note>
         <target xml:lang="es-ES" state="translated">Error al cargar el archivo:\n{0}\nSi este no es un archivo esencial, puede eliminarlo sin preocupación y/o ignorar este error.</target>
+        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FailedToLoadOtherFile</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.GenericFileTypeViewer.FailedToOpen">
         <source xml:lang="en">Failed to open file: {0}</source>
-        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FailedToOpen</note>
         <target xml:lang="es-ES" state="translated">Error al abrir el archivo: {0}</target>
+        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FailedToOpen</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.GenericFileTypeViewer.FileLabel">
         <source xml:lang="en">File:</source>
-        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FileLabel</note>
         <target xml:lang="es-ES" state="translated">Archivo:</target>
+        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FileLabel</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.GenericFileTypeViewer.FileLinkMsg">
         <source xml:lang="en">Open {0} in its associated program.</source>
-        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FileLinkMsg</note>
         <target xml:lang="es-ES" state="translated">Abrir {0} en su programa asociado.</target>
+        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FileLinkMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble">
         <source xml:lang="en">{0} attempted to load:</source>
-        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble</note>
-        <note>Param is "SayMore" (program name)</note>
         <target xml:lang="es-ES" state="translated">{0} intentó cargar:</target>
+        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FileNameMsgPreamble</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.GenericFileTypeViewer.FolderLabel">
         <source xml:lang="en">Folder:</source>
-        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FolderLabel</note>
         <target xml:lang="es-ES" state="translated">Carpeta:</target>
+        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.FolderLabel</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.GenericFileTypeViewer.TabText">
         <source xml:lang="en">View</source>
-        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.TabText</note>
         <target xml:lang="es-ES" state="translated">Vista</target>
+        <note>ID: CommonToMultipleViews.GenericFileTypeViewer.TabText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ImageViewer.OpeningPictureFileErrorMsg">
         <source xml:lang="en">Could not open that picture.</source>
-        <note>ID: CommonToMultipleViews.ImageViewer.OpeningPictureFileErrorMsg</note>
         <target xml:lang="es-ES" state="translated">No se pudo abrir la imagen.</target>
+        <note>ID: CommonToMultipleViews.ImageViewer.OpeningPictureFileErrorMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ImageViewer.OpeningPictureFileTooLargeMsg">
         <source xml:lang="en">Could not open that picture. The image size is too large for SayMore to open.</source>
-        <note>ID: CommonToMultipleViews.ImageViewer.OpeningPictureFileTooLargeMsg</note>
         <target xml:lang="es-ES" state="translated">No se pudo abrir la imagen porque es demasiado grande para SayMore.</target>
+        <note>ID: CommonToMultipleViews.ImageViewer.OpeningPictureFileTooLargeMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ImageViewer.TabText">
         <source xml:lang="en">Image</source>
-        <note>ID: CommonToMultipleViews.ImageViewer.TabText</note>
         <target xml:lang="es-ES" state="translated">Imagen</target>
+        <note>ID: CommonToMultipleViews.ImageViewer.TabText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ImageViewer.ZoomLabel">
         <source xml:lang="en">Zoom</source>
-        <note>ID: CommonToMultipleViews.ImageViewer.ZoomLabel</note>
         <target xml:lang="es-ES" state="translated">Zoom</target>
+        <note>ID: CommonToMultipleViews.ImageViewer.ZoomLabel</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.ListItems.Content-Interactivity.Interactive.Definition" sil:dynamic="true">
+        <source xml:lang="en">Speech events consists of verbal interaction between at least two participants. Comments: The event may or may not include an investigator.</source>
+        <target xml:lang="es-ES" state="translated">Los eventos de discurso consisten en interacción verbal entre al menos dos participantes. Comentarios: El evento puede incluir un investigador, pero no es obligatorio.</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Interactivity.Interactive.Definition</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.ListItems.Content-Interactivity.Interactive.Text" sil:dynamic="true">
+        <source xml:lang="en">Interactive</source>
+        <target xml:lang="es-ES" state="translated">Interactivo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Interactivity.Interactive.Text</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.ListItems.Content-Interactivity.Non-interactive.Definition" sil:dynamic="true">
+        <source xml:lang="en">Speech/song produced without expecting extended verbal responses from hearer(s). Comments: Corresponds often to monologue.</source>
+        <target xml:lang="es-ES" state="translated">Discurso o canción producido sin esperar respuestas verbales extendidas de los oyentes(s). Comentarios: Corresponde a menudo a un monólogo.</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Interactivity.Non-interactive.Definition</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.ListItems.Content-Interactivity.Non-interactive.Text" sil:dynamic="true">
+        <source xml:lang="en">Non-interactive</source>
+        <target xml:lang="es-ES" state="translated">No interactivo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Interactivity.Non-interactive.Text</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.ListItems.Content-Interactivity.Semi-interactive.Definition" sil:dynamic="true">
+        <source xml:lang="en">Primarily monologic speech punctuated by repeated interjections from the hearer(s).</source>
+        <target xml:lang="es-ES" state="needs-translation">Primarily monologic speech punctuated by repeated interjections from the hearer(s).</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Interactivity.Semi-interactive.Definition</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.ListItems.Content-Interactivity.Semi-interactive.Text" sil:dynamic="true">
+        <source xml:lang="en">Semi-interactive</source>
+        <target xml:lang="es-ES" state="translated">Semi-interactivo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Interactivity.Semi-interactive.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-Involvement.Elicited.Definition" sil:dynamic="true">
         <source xml:lang="en">Investigator asks speaker(s) to produce isolated phonemes/ words/ utterances / grammatical structures.</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.Elicited.Definition</note>
         <target xml:lang="es-ES" state="translated">Investigador pide al hablante que produzca fonemas aislados, palabras, expresiones, o estructuras gramaticales.</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.Elicited.Definition</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-Involvement.Elicited.Text" sil:dynamic="true">
         <source xml:lang="en">Elicited</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.Elicited.Text</note>
         <target xml:lang="es-ES" state="translated">Suscitada</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.Elicited.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-Involvement.No-observer.Definition" sil:dynamic="true">
         <source xml:lang="en">No outside observer is present.</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.No-observer.Definition</note>
         <target xml:lang="es-ES" state="translated">Ningún observador externo está presente.</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.No-observer.Definition</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-Involvement.No-observer.Text" sil:dynamic="true">
         <source xml:lang="en">No-observer</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.No-observer.Text</note>
         <target xml:lang="es-ES" state="translated">Ningún observador</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.No-observer.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-Involvement.Non-elicited.Definition" sil:dynamic="true">
         <source xml:lang="en">The researcher does not interfere verbally with the speech event (other than the researcher's mere presence).</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.Non-elicited.Definition</note>
         <target xml:lang="es-ES" state="translated">El investigador no interfiere verbalmente con el evento comunicativo (aparte de la mera presencia del investigador).</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.Non-elicited.Definition</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-Involvement.Non-elicited.Text" sil:dynamic="true">
         <source xml:lang="en">Non-elicited</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.Non-elicited.Text</note>
         <target xml:lang="es-ES" state="translated">Espontánea</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-Involvement.Non-elicited.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-PlanningType.Planned.Definition" sil:dynamic="true">
         <source xml:lang="en">The speaker prepares in detail the structure and content of his/her "performance" in advance Comments: This differs from 'Elicitation' (involvement), where the performer/consultant is given a framework but does not necessary plan his/her answer.</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Planned.Definition</note>
         <target xml:lang="es-ES" state="translated">El orador prepara en detalle la estructura y el contenido de su "desempeño" de antemano. Comentarios: Esto difiere de la 'suscitación' (participación), donde se le da un marco al artista / ejecutante / consultor pero éste no necesariamente planea su respuesta.</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Planned.Definition</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-PlanningType.Planned.Text" sil:dynamic="true">
         <source xml:lang="en">Planned</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Planned.Text</note>
         <target xml:lang="es-ES" state="translated">Planeado</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Planned.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-PlanningType.Semi-spontaneous.Definition" sil:dynamic="true">
         <source xml:lang="en">Prompted speech/song. Comments: Topic directed in some way by an investigator or community member, but participants speak/sing freely within this context.</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Semi-spontaneous.Definition</note>
         <target xml:lang="es-ES" state="translated">Discurso o canción suscitado/a. Comentario: Tema dirigida de alguna manera por un investigador o un miembro de la comunidad, pero los participantes hablan o cantan libremente dentro de este contexto.</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Semi-spontaneous.Definition</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-PlanningType.Semi-spontaneous.Text" sil:dynamic="true">
         <source xml:lang="en">Semi-spontaneous</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Semi-spontaneous.Text</note>
         <target xml:lang="es-ES" state="translated">Semi espontáneo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Semi-spontaneous.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-PlanningType.Spontaneous.Definition" sil:dynamic="true">
         <source xml:lang="en">Unprompted speech/song. Comments: Topic not determined from context or observers.</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Spontaneous.Definition</note>
         <target xml:lang="es-ES" state="translated">Discurso o canción no suscitado/a. Comentario: Tema no determinado por el contexto ni por los observadores.</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Spontaneous.Definition</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-PlanningType.Spontaneous.Text" sil:dynamic="true">
         <source xml:lang="en">Spontaneous</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Spontaneous.Text</note>
         <target xml:lang="es-ES" state="translated">Espontáneo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-PlanningType.Spontaneous.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-SocialContext.Controlled environment.Text" sil:dynamic="true">
         <source xml:lang="en">Controlled environment</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-SocialContext.Controlled environment.Text</note>
         <target xml:lang="es-ES" state="translated">Ambiente controlado</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-SocialContext.Controlled environment.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-SocialContext.Family.Text" sil:dynamic="true">
         <source xml:lang="en">Family</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-SocialContext.Family.Text</note>
         <target xml:lang="es-ES" state="translated">Familia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-SocialContext.Family.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-SocialContext.Private.Text" sil:dynamic="true">
         <source xml:lang="en">Private</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-SocialContext.Private.Text</note>
         <target xml:lang="es-ES" state="translated">Privado</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-SocialContext.Private.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Content-SocialContext.Public.Text" sil:dynamic="true">
         <source xml:lang="en">Public</source>
-        <note>ID: CommonToMultipleViews.ListItems.Content-SocialContext.Public.Text</note>
         <target xml:lang="es-ES" state="translated">Público</target>
+        <note>ID: CommonToMultipleViews.ListItems.Content-SocialContext.Public.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Continents.Africa.Text" sil:dynamic="true">
         <source xml:lang="en">Africa</source>
-        <note>ID: CommonToMultipleViews.ListItems.Continents.Africa.Text</note>
         <target xml:lang="es-ES" state="translated">África</target>
+        <note>ID: CommonToMultipleViews.ListItems.Continents.Africa.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Continents.Asia.Text" sil:dynamic="true">
         <source xml:lang="en">Asia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Continents.Asia.Text</note>
         <target xml:lang="es-ES" state="translated">Asia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Continents.Asia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Continents.Australia.Text" sil:dynamic="true">
         <source xml:lang="en">Australia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Continents.Australia.Text</note>
         <target xml:lang="es-ES" state="translated">Australia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Continents.Australia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Continents.Europe.Text" sil:dynamic="true">
         <source xml:lang="en">Europe</source>
-        <note>ID: CommonToMultipleViews.ListItems.Continents.Europe.Text</note>
         <target xml:lang="es-ES" state="translated">Europa</target>
+        <note>ID: CommonToMultipleViews.ListItems.Continents.Europe.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Continents.Middle-America.Text" sil:dynamic="true">
         <source xml:lang="en">Middle-America</source>
-        <note>ID: CommonToMultipleViews.ListItems.Continents.Middle-America.Text</note>
         <target xml:lang="es-ES" state="translated">Centroamérica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Continents.Middle-America.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Continents.North-America.Text" sil:dynamic="true">
         <source xml:lang="en">North-America</source>
-        <note>ID: CommonToMultipleViews.ListItems.Continents.North-America.Text</note>
         <target xml:lang="es-ES" state="translated">Norteamérica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Continents.North-America.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Continents.Oceania.Text" sil:dynamic="true">
         <source xml:lang="en">Oceania</source>
-        <note>ID: CommonToMultipleViews.ListItems.Continents.Oceania.Text</note>
         <target xml:lang="es-ES" state="translated">Oceanía</target>
+        <note>ID: CommonToMultipleViews.ListItems.Continents.Oceania.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Continents.South-America.Text" sil:dynamic="true">
         <source xml:lang="en">South-America</source>
-        <note>ID: CommonToMultipleViews.ListItems.Continents.South-America.Text</note>
         <target xml:lang="es-ES" state="translated">Sudamérica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Continents.South-America.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Afghanistan.Text" sil:dynamic="true">
         <source xml:lang="en">Afghanistan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Afghanistan.Text</note>
         <target xml:lang="es-ES" state="translated">Afganistán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Afghanistan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Albania.Text" sil:dynamic="true">
         <source xml:lang="en">Albania</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Albania.Text</note>
         <target xml:lang="es-ES" state="translated">Albania</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Albania.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Algeria.Text" sil:dynamic="true">
         <source xml:lang="en">Algeria</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Algeria.Text</note>
         <target xml:lang="es-ES" state="translated">Argelia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Algeria.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.American Samoa.Text" sil:dynamic="true">
         <source xml:lang="en">American Samoa</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.American Samoa.Text</note>
         <target xml:lang="es-ES" state="translated">Samoa Americana</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.American Samoa.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Andorra.Text" sil:dynamic="true">
         <source xml:lang="en">Andorra</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Andorra.Text</note>
         <target xml:lang="es-ES" state="translated">Andorra</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Andorra.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Angola.Text" sil:dynamic="true">
         <source xml:lang="en">Angola</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Angola.Text</note>
         <target xml:lang="es-ES" state="translated">Angola</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Angola.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Anguilla.Text" sil:dynamic="true">
         <source xml:lang="en">Anguilla</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Anguilla.Text</note>
         <target xml:lang="es-ES" state="translated">Anguila</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Anguilla.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Antarctica.Text" sil:dynamic="true">
         <source xml:lang="en">Antarctica</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Antarctica.Text</note>
         <target xml:lang="es-ES" state="translated">Antártida</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Antarctica.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Antigua and Barbuda.Text" sil:dynamic="true">
         <source xml:lang="en">Antigua and Barbuda</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Antigua and Barbuda.Text</note>
         <target xml:lang="es-ES" state="translated">Antigua y Barbuda</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Antigua and Barbuda.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Arctic Ocean.Text" sil:dynamic="true">
         <source xml:lang="en">Arctic Ocean</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Arctic Ocean.Text</note>
         <target xml:lang="es-ES" state="translated">Océano Ártico</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Arctic Ocean.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Argentina.Text" sil:dynamic="true">
         <source xml:lang="en">Argentina</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Argentina.Text</note>
         <target xml:lang="es-ES" state="translated">Argentina</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Argentina.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Armenia.Text" sil:dynamic="true">
         <source xml:lang="en">Armenia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Armenia.Text</note>
         <target xml:lang="es-ES" state="translated">Armenia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Armenia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Aruba.Text" sil:dynamic="true">
         <source xml:lang="en">Aruba</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Aruba.Text</note>
         <target xml:lang="es-ES" state="translated">Aruba</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Aruba.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Ashmore and Cartier Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Ashmore and Cartier Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Ashmore and Cartier Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Ashmore y Cartier</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Ashmore and Cartier Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Atlantic Ocean.Text" sil:dynamic="true">
         <source xml:lang="en">Atlantic Ocean</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Atlantic Ocean.Text</note>
         <target xml:lang="es-ES" state="translated">Océano Atlántico</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Atlantic Ocean.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Australia.Text" sil:dynamic="true">
         <source xml:lang="en">Australia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Australia.Text</note>
         <target xml:lang="es-ES" state="translated">Australia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Australia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Austria.Text" sil:dynamic="true">
         <source xml:lang="en">Austria</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Austria.Text</note>
         <target xml:lang="es-ES" state="translated">Austria</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Austria.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Azerbaijan.Text" sil:dynamic="true">
         <source xml:lang="en">Azerbaijan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Azerbaijan.Text</note>
         <target xml:lang="es-ES" state="translated">Azerbaiyán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Azerbaijan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bahamas.Text" sil:dynamic="true">
         <source xml:lang="en">Bahamas</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bahamas.Text</note>
         <target xml:lang="es-ES" state="translated">Bahamas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bahamas.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bahrain.Text" sil:dynamic="true">
         <source xml:lang="en">Bahrain</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bahrain.Text</note>
         <target xml:lang="es-ES" state="translated">Baréin</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bahrain.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Baker Island.Text" sil:dynamic="true">
         <source xml:lang="en">Baker Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Baker Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla de Baker</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Baker Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bangladesh.Text" sil:dynamic="true">
         <source xml:lang="en">Bangladesh</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bangladesh.Text</note>
         <target xml:lang="es-ES" state="translated">Bangladés</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bangladesh.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Barbados.Text" sil:dynamic="true">
         <source xml:lang="en">Barbados</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Barbados.Text</note>
         <target xml:lang="es-ES" state="translated">Barbados</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Barbados.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bassas da India.Text" sil:dynamic="true">
         <source xml:lang="en">Bassas da India</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bassas da India.Text</note>
         <target xml:lang="es-ES" state="translated">Bassas da India</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bassas da India.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Belarus.Text" sil:dynamic="true">
         <source xml:lang="en">Belarus</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Belarus.Text</note>
         <target xml:lang="es-ES" state="translated">Bielorrusia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Belarus.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Belgium.Text" sil:dynamic="true">
         <source xml:lang="en">Belgium</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Belgium.Text</note>
         <target xml:lang="es-ES" state="translated">Bélgica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Belgium.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Belize.Text" sil:dynamic="true">
         <source xml:lang="en">Belize</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Belize.Text</note>
         <target xml:lang="es-ES" state="translated">Belice</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Belize.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Benin.Text" sil:dynamic="true">
         <source xml:lang="en">Benin</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Benin.Text</note>
         <target xml:lang="es-ES" state="translated">Benín</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Benin.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bermuda.Text" sil:dynamic="true">
         <source xml:lang="en">Bermuda</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bermuda.Text</note>
         <target xml:lang="es-ES" state="translated">Bermudas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bermuda.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bhutan.Text" sil:dynamic="true">
         <source xml:lang="en">Bhutan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bhutan.Text</note>
         <target xml:lang="es-ES" state="translated">Bután</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bhutan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bolivia.Text" sil:dynamic="true">
         <source xml:lang="en">Bolivia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bolivia.Text</note>
         <target xml:lang="es-ES" state="translated">Bolivia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bolivia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bosnia and Herzegovina.Text" sil:dynamic="true">
         <source xml:lang="en">Bosnia and Herzegovina</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bosnia and Herzegovina.Text</note>
         <target xml:lang="es-ES" state="translated">Bosnia-Herzegovina</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bosnia and Herzegovina.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Botswana.Text" sil:dynamic="true">
         <source xml:lang="en">Botswana</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Botswana.Text</note>
         <target xml:lang="es-ES" state="translated">Botswana</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Botswana.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bouvet Island.Text" sil:dynamic="true">
         <source xml:lang="en">Bouvet Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bouvet Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Bouvet</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bouvet Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Brazil.Text" sil:dynamic="true">
         <source xml:lang="en">Brazil</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Brazil.Text</note>
         <target xml:lang="es-ES" state="translated">Brasil</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Brazil.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.British Indian Ocean Territory.Text" sil:dynamic="true">
         <source xml:lang="en">British Indian Ocean Territory</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.British Indian Ocean Territory.Text</note>
         <target xml:lang="es-ES" state="translated">Territorio Británico del Océano Índico</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.British Indian Ocean Territory.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.British Virgin Islands.Text" sil:dynamic="true">
         <source xml:lang="en">British Virgin Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.British Virgin Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Vírgenes Británicas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.British Virgin Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Brunei.Text" sil:dynamic="true">
         <source xml:lang="en">Brunei</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Brunei.Text</note>
         <target xml:lang="es-ES" state="translated">Brunéi</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Brunei.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Bulgaria.Text" sil:dynamic="true">
         <source xml:lang="en">Bulgaria</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Bulgaria.Text</note>
         <target xml:lang="es-ES" state="translated">Bulgaria</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Bulgaria.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Burkina Faso.Text" sil:dynamic="true">
         <source xml:lang="en">Burkina Faso</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Burkina Faso.Text</note>
         <target xml:lang="es-ES" state="translated">Burkina Faso</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Burkina Faso.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Burma.Text" sil:dynamic="true">
         <source xml:lang="en">Burma</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Burma.Text</note>
         <target xml:lang="es-ES" state="translated">Birmania (Myanmar)</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Burma.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Burundi.Text" sil:dynamic="true">
         <source xml:lang="en">Burundi</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Burundi.Text</note>
         <target xml:lang="es-ES" state="translated">Burundi</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Burundi.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cambodia.Text" sil:dynamic="true">
         <source xml:lang="en">Cambodia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cambodia.Text</note>
         <target xml:lang="es-ES" state="translated">Camboya</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cambodia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cameroon.Text" sil:dynamic="true">
         <source xml:lang="en">Cameroon</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cameroon.Text</note>
         <target xml:lang="es-ES" state="translated">Camerún</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cameroon.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Canada.Text" sil:dynamic="true">
         <source xml:lang="en">Canada</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Canada.Text</note>
         <target xml:lang="es-ES" state="translated">Canadá</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Canada.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cape Verde.Text" sil:dynamic="true">
         <source xml:lang="en">Cape Verde</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cape Verde.Text</note>
         <target xml:lang="es-ES" state="translated">Cabo Verde</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cape Verde.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cayman Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Cayman Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cayman Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Caimán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cayman Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Central African Republic.Text" sil:dynamic="true">
         <source xml:lang="en">Central African Republic</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Central African Republic.Text</note>
         <target xml:lang="es-ES" state="translated">República Centroafricana</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Central African Republic.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Chad.Text" sil:dynamic="true">
         <source xml:lang="en">Chad</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Chad.Text</note>
         <target xml:lang="es-ES" state="translated">Chad</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Chad.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Chile.Text" sil:dynamic="true">
         <source xml:lang="en">Chile</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Chile.Text</note>
         <target xml:lang="es-ES" state="translated">Chile</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Chile.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.China.Text" sil:dynamic="true">
         <source xml:lang="en">China</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.China.Text</note>
         <target xml:lang="es-ES" state="translated">China</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.China.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Christmas Island.Text" sil:dynamic="true">
         <source xml:lang="en">Christmas Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Christmas Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla De Navidad, Isla Christmas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Christmas Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Clipperton Island.Text" sil:dynamic="true">
         <source xml:lang="en">Clipperton Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Clipperton Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Clipperton</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Clipperton Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cocos (Keeling Islands).Text" sil:dynamic="true">
         <source xml:lang="en">Cocos (Keeling Islands)</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cocos (Keeling Islands).Text</note>
         <target xml:lang="es-ES" state="translated">Islas Cocos</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cocos (Keeling Islands).Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Colombia.Text" sil:dynamic="true">
         <source xml:lang="en">Colombia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Colombia.Text</note>
         <target xml:lang="es-ES" state="translated">Colombia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Colombia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Comoros.Text" sil:dynamic="true">
         <source xml:lang="en">Comoros</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Comoros.Text</note>
         <target xml:lang="es-ES" state="translated">Comores</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Comoros.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Congo Republic of the.Text" sil:dynamic="true">
         <source xml:lang="en">Congo Republic of the</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Congo Republic of the.Text</note>
         <target xml:lang="es-ES" state="translated">República del Congo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Congo Republic of the.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Congo, Democratic Republic of the.Text" sil:dynamic="true">
         <source xml:lang="en">Congo, Democratic Republic of the</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Congo, Democratic Republic of the.Text</note>
         <target xml:lang="es-ES" state="translated">República Democrática del Congo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Congo, Democratic Republic of the.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cook Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Cook Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cook Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Cook</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cook Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Coral Sea Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Coral Sea Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Coral Sea Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas del Mar del Coral</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Coral Sea Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Costa Rica.Text" sil:dynamic="true">
         <source xml:lang="en">Costa Rica</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Costa Rica.Text</note>
         <target xml:lang="es-ES" state="translated">Costa Rica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Costa Rica.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cote D'Ivoire.Text" sil:dynamic="true">
         <source xml:lang="en">Cote D'Ivoire</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cote D'Ivoire.Text</note>
         <target xml:lang="es-ES" state="translated">Costa de Marfil</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cote D'Ivoire.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Croatia.Text" sil:dynamic="true">
         <source xml:lang="en">Croatia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Croatia.Text</note>
         <target xml:lang="es-ES" state="translated">Croacia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Croatia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cuba.Text" sil:dynamic="true">
         <source xml:lang="en">Cuba</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cuba.Text</note>
         <target xml:lang="es-ES" state="translated">Cuba</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cuba.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Cyprus.Text" sil:dynamic="true">
         <source xml:lang="en">Cyprus</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Cyprus.Text</note>
         <target xml:lang="es-ES" state="translated">Chipre</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Cyprus.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Czech Republic.Text" sil:dynamic="true">
         <source xml:lang="en">Czech Republic</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Czech Republic.Text</note>
         <target xml:lang="es-ES" state="translated">República Checa</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Czech Republic.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Denmark.Text" sil:dynamic="true">
         <source xml:lang="en">Denmark</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Denmark.Text</note>
         <target xml:lang="es-ES" state="translated">Dinamarca</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Denmark.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Djibouti.Text" sil:dynamic="true">
         <source xml:lang="en">Djibouti</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Djibouti.Text</note>
         <target xml:lang="es-ES" state="translated">Djibouti, Yibuti</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Djibouti.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Dominica.Text" sil:dynamic="true">
         <source xml:lang="en">Dominica</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Dominica.Text</note>
         <target xml:lang="es-ES" state="translated">Dominica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Dominica.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Dominican Republic.Text" sil:dynamic="true">
         <source xml:lang="en">Dominican Republic</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Dominican Republic.Text</note>
         <target xml:lang="es-ES" state="translated">Dominicana, República</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Dominican Republic.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.East Timor.Text" sil:dynamic="true">
         <source xml:lang="en">East Timor</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.East Timor.Text</note>
         <target xml:lang="es-ES" state="translated">Timor Oriental</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.East Timor.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Ecuador.Text" sil:dynamic="true">
         <source xml:lang="en">Ecuador</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Ecuador.Text</note>
         <target xml:lang="es-ES" state="translated">Ecuador</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Ecuador.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Egypt.Text" sil:dynamic="true">
         <source xml:lang="en">Egypt</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Egypt.Text</note>
         <target xml:lang="es-ES" state="translated">Egipto</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Egypt.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.El Salvador.Text" sil:dynamic="true">
         <source xml:lang="en">El Salvador</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.El Salvador.Text</note>
         <target xml:lang="es-ES" state="translated">El Salvador</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.El Salvador.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Equatorial Guinea.Text" sil:dynamic="true">
         <source xml:lang="en">Equatorial Guinea</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Equatorial Guinea.Text</note>
         <target xml:lang="es-ES" state="translated">Guinea Ecuatorial</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Equatorial Guinea.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Eritrea.Text" sil:dynamic="true">
         <source xml:lang="en">Eritrea</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Eritrea.Text</note>
         <target xml:lang="es-ES" state="translated">Eritrea</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Eritrea.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Estonia.Text" sil:dynamic="true">
         <source xml:lang="en">Estonia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Estonia.Text</note>
         <target xml:lang="es-ES" state="translated">Estonia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Estonia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Ethiopia.Text" sil:dynamic="true">
         <source xml:lang="en">Ethiopia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Ethiopia.Text</note>
         <target xml:lang="es-ES" state="translated">Etiopía</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Ethiopia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Europa Island.Text" sil:dynamic="true">
         <source xml:lang="en">Europa Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Europa Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Europa</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Europa Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Falkland Islands (Islas Malvinas).Text" sil:dynamic="true">
         <source xml:lang="en">Falkland Islands (Islas Malvinas)</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Falkland Islands (Islas Malvinas).Text</note>
         <target xml:lang="es-ES" state="translated">Islas Malvinas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Falkland Islands (Islas Malvinas).Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Faroer Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Faroer Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Faroer Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Feroe</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Faroer Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Fiji.Text" sil:dynamic="true">
         <source xml:lang="en">Fiji</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Fiji.Text</note>
         <target xml:lang="es-ES" state="translated">Fiyi</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Fiji.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Finland.Text" sil:dynamic="true">
         <source xml:lang="en">Finland</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Finland.Text</note>
         <target xml:lang="es-ES" state="translated">Finlandia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Finland.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.France.Text" sil:dynamic="true">
         <source xml:lang="en">France</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.France.Text</note>
         <target xml:lang="es-ES" state="translated">Francia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.France.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.French Guiana.Text" sil:dynamic="true">
         <source xml:lang="en">French Guiana</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.French Guiana.Text</note>
         <target xml:lang="es-ES" state="translated">Guayana Francesa</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.French Guiana.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.French Polynesia.Text" sil:dynamic="true">
         <source xml:lang="en">French Polynesia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.French Polynesia.Text</note>
         <target xml:lang="es-ES" state="translated">Polinesia Francesa</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.French Polynesia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.French Southern and Antarctic Lands.Text" sil:dynamic="true">
         <source xml:lang="en">French Southern and Antarctic Lands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.French Southern and Antarctic Lands.Text</note>
         <target xml:lang="es-ES" state="translated">Tierras Australes y Antárticas Francesas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.French Southern and Antarctic Lands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Gabon.Text" sil:dynamic="true">
         <source xml:lang="en">Gabon</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Gabon.Text</note>
         <target xml:lang="es-ES" state="translated">Gabón</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Gabon.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Gambia.Text" sil:dynamic="true">
         <source xml:lang="en">Gambia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Gambia.Text</note>
         <target xml:lang="es-ES" state="translated">Gambia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Gambia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Georgia.Text" sil:dynamic="true">
         <source xml:lang="en">Georgia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Georgia.Text</note>
         <target xml:lang="es-ES" state="translated">Georgia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Georgia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Germany.Text" sil:dynamic="true">
         <source xml:lang="en">Germany</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Germany.Text</note>
         <target xml:lang="es-ES" state="translated">Alemania</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Germany.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Ghana.Text" sil:dynamic="true">
         <source xml:lang="en">Ghana</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Ghana.Text</note>
         <target xml:lang="es-ES" state="translated">Ghana</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Ghana.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Gibraltar.Text" sil:dynamic="true">
         <source xml:lang="en">Gibraltar</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Gibraltar.Text</note>
         <target xml:lang="es-ES" state="translated">Gibraltar</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Gibraltar.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Glorioso Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Glorioso Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Glorioso Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Gloriosas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Glorioso Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Greece.Text" sil:dynamic="true">
         <source xml:lang="en">Greece</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Greece.Text</note>
         <target xml:lang="es-ES" state="translated">Grecia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Greece.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Greenland.Text" sil:dynamic="true">
         <source xml:lang="en">Greenland</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Greenland.Text</note>
         <target xml:lang="es-ES" state="translated">Groenlandia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Greenland.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Grenada.Text" sil:dynamic="true">
         <source xml:lang="en">Grenada</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Grenada.Text</note>
         <target xml:lang="es-ES" state="translated">Granada</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Grenada.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Guadeloupe.Text" sil:dynamic="true">
         <source xml:lang="en">Guadeloupe</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Guadeloupe.Text</note>
         <target xml:lang="es-ES" state="translated">Guadalupe</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Guadeloupe.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Guam.Text" sil:dynamic="true">
         <source xml:lang="en">Guam</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Guam.Text</note>
         <target xml:lang="es-ES" state="translated">Guam</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Guam.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Guatemala.Text" sil:dynamic="true">
         <source xml:lang="en">Guatemala</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Guatemala.Text</note>
         <target xml:lang="es-ES" state="translated">Guatemala</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Guatemala.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Guernsey.Text" sil:dynamic="true">
         <source xml:lang="en">Guernsey</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Guernsey.Text</note>
         <target xml:lang="es-ES" state="translated">El Bailiazgo de Guernsey</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Guernsey.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Guinea-Bissau.Text" sil:dynamic="true">
         <source xml:lang="en">Guinea-Bissau</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Guinea-Bissau.Text</note>
         <target xml:lang="es-ES" state="translated">Guinea Bissau</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Guinea-Bissau.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Guinea.Text" sil:dynamic="true">
         <source xml:lang="en">Guinea</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Guinea.Text</note>
         <target xml:lang="es-ES" state="translated">República Guinea</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Guinea.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Guyana.Text" sil:dynamic="true">
         <source xml:lang="en">Guyana</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Guyana.Text</note>
         <target xml:lang="es-ES" state="translated">Guyana</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Guyana.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Haiti.Text" sil:dynamic="true">
         <source xml:lang="en">Haiti</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Haiti.Text</note>
         <target xml:lang="es-ES" state="translated">Haití</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Haiti.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Heard and McDonald Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Heard and McDonald Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Heard and McDonald Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Heard y McDonald</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Heard and McDonald Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Holy See (Vatican City).Text" sil:dynamic="true">
         <source xml:lang="en">Holy See (Vatican City)</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Holy See (Vatican City).Text</note>
         <target xml:lang="es-ES" state="translated">Santa Sede (Ciudad del Vaticano)</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Holy See (Vatican City).Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Honduras.Text" sil:dynamic="true">
         <source xml:lang="en">Honduras</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Honduras.Text</note>
         <target xml:lang="es-ES" state="translated">Honduras</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Honduras.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Hong Kong.Text" sil:dynamic="true">
         <source xml:lang="en">Hong Kong</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Hong Kong.Text</note>
         <target xml:lang="es-ES" state="translated">Hong Kong</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Hong Kong.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Howland Island.Text" sil:dynamic="true">
         <source xml:lang="en">Howland Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Howland Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Howland</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Howland Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Hungary.Text" sil:dynamic="true">
         <source xml:lang="en">Hungary</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Hungary.Text</note>
         <target xml:lang="es-ES" state="translated">Hungría</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Hungary.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Iceland.Text" sil:dynamic="true">
         <source xml:lang="en">Iceland</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Iceland.Text</note>
         <target xml:lang="es-ES" state="translated">Islandia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Iceland.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.India.Text" sil:dynamic="true">
         <source xml:lang="en">India</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.India.Text</note>
         <target xml:lang="es-ES" state="translated">India</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.India.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Indian Ocean.Text" sil:dynamic="true">
         <source xml:lang="en">Indian Ocean</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Indian Ocean.Text</note>
         <target xml:lang="es-ES" state="translated">Océano Índico</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Indian Ocean.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Indonesia.Text" sil:dynamic="true">
         <source xml:lang="en">Indonesia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Indonesia.Text</note>
         <target xml:lang="es-ES" state="translated">Indonesia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Indonesia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Iran.Text" sil:dynamic="true">
         <source xml:lang="en">Iran</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Iran.Text</note>
         <target xml:lang="es-ES" state="translated">Irán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Iran.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Iraq.Text" sil:dynamic="true">
         <source xml:lang="en">Iraq</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Iraq.Text</note>
         <target xml:lang="es-ES" state="translated">Iraq</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Iraq.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Ireland.Text" sil:dynamic="true">
         <source xml:lang="en">Ireland</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Ireland.Text</note>
         <target xml:lang="es-ES" state="translated">Irlanda</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Ireland.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Israel.Text" sil:dynamic="true">
         <source xml:lang="en">Israel</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Israel.Text</note>
         <target xml:lang="es-ES" state="translated">Israel</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Israel.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Italy.Text" sil:dynamic="true">
         <source xml:lang="en">Italy</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Italy.Text</note>
         <target xml:lang="es-ES" state="translated">Italia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Italy.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Jamaica.Text" sil:dynamic="true">
         <source xml:lang="en">Jamaica</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Jamaica.Text</note>
         <target xml:lang="es-ES" state="translated">Jamaica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Jamaica.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Jan Mayen.Text" sil:dynamic="true">
         <source xml:lang="en">Jan Mayen</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Jan Mayen.Text</note>
         <target xml:lang="es-ES" state="translated">Jan Mayen</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Jan Mayen.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Japan.Text" sil:dynamic="true">
         <source xml:lang="en">Japan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Japan.Text</note>
         <target xml:lang="es-ES" state="translated">Japón</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Japan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Jarvis Island.Text" sil:dynamic="true">
         <source xml:lang="en">Jarvis Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Jarvis Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Jarvis</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Jarvis Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Jersey.Text" sil:dynamic="true">
         <source xml:lang="en">Jersey</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Jersey.Text</note>
         <target xml:lang="es-ES" state="translated">Bailiazgo de Jersey</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Jersey.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Johnston Atoll.Text" sil:dynamic="true">
         <source xml:lang="en">Johnston Atoll</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Johnston Atoll.Text</note>
         <target xml:lang="es-ES" state="translated">Atolón Johnston</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Johnston Atoll.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Jordan.Text" sil:dynamic="true">
         <source xml:lang="en">Jordan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Jordan.Text</note>
         <target xml:lang="es-ES" state="translated">Jordania</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Jordan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Juan de Nova Island.Text" sil:dynamic="true">
         <source xml:lang="en">Juan de Nova Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Juan de Nova Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Juan de Nova</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Juan de Nova Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Kazakhstan.Text" sil:dynamic="true">
         <source xml:lang="en">Kazakhstan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Kazakhstan.Text</note>
         <target xml:lang="es-ES" state="translated">Kazajstán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Kazakhstan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Kenya.Text" sil:dynamic="true">
         <source xml:lang="en">Kenya</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Kenya.Text</note>
         <target xml:lang="es-ES" state="translated">Kenia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Kenya.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Kingman Reef.Text" sil:dynamic="true">
         <source xml:lang="en">Kingman Reef</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Kingman Reef.Text</note>
         <target xml:lang="es-ES" state="translated">Arrecife Kingman</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Kingman Reef.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Kiribati.Text" sil:dynamic="true">
         <source xml:lang="en">Kiribati</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Kiribati.Text</note>
         <target xml:lang="es-ES" state="translated">Kiribati</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Kiribati.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Korea (North).Text" sil:dynamic="true">
         <source xml:lang="en">Korea (North)</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Korea (North).Text</note>
         <target xml:lang="es-ES" state="translated">Corea del Norte</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Korea (North).Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Korea (South).Text" sil:dynamic="true">
         <source xml:lang="en">Korea (South)</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Korea (South).Text</note>
         <target xml:lang="es-ES" state="translated">Corea del Sur</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Korea (South).Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Kuwait.Text" sil:dynamic="true">
         <source xml:lang="en">Kuwait</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Kuwait.Text</note>
         <target xml:lang="es-ES" state="translated">Kuwait</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Kuwait.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Kyrgyzstan.Text" sil:dynamic="true">
         <source xml:lang="en">Kyrgyzstan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Kyrgyzstan.Text</note>
         <target xml:lang="es-ES" state="translated">Kirguistán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Kyrgyzstan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Laos.Text" sil:dynamic="true">
         <source xml:lang="en">Laos</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Laos.Text</note>
         <target xml:lang="es-ES" state="translated">Laos (República Democrática Popular Lao)</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Laos.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Latvia.Text" sil:dynamic="true">
         <source xml:lang="en">Latvia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Latvia.Text</note>
         <target xml:lang="es-ES" state="translated">Letonia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Latvia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Lebanon.Text" sil:dynamic="true">
         <source xml:lang="en">Lebanon</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Lebanon.Text</note>
         <target xml:lang="es-ES" state="translated">Líbano</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Lebanon.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Lesotho.Text" sil:dynamic="true">
         <source xml:lang="en">Lesotho</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Lesotho.Text</note>
         <target xml:lang="es-ES" state="translated">Lesotho</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Lesotho.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Liberia.Text" sil:dynamic="true">
         <source xml:lang="en">Liberia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Liberia.Text</note>
         <target xml:lang="es-ES" state="translated">Liberia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Liberia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Libya.Text" sil:dynamic="true">
         <source xml:lang="en">Libya</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Libya.Text</note>
         <target xml:lang="es-ES" state="translated">Libia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Libya.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Liechtenstein.Text" sil:dynamic="true">
         <source xml:lang="en">Liechtenstein</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Liechtenstein.Text</note>
         <target xml:lang="es-ES" state="translated">Liechtenstein</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Liechtenstein.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Lithuania.Text" sil:dynamic="true">
         <source xml:lang="en">Lithuania</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Lithuania.Text</note>
         <target xml:lang="es-ES" state="translated">Lituania</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Lithuania.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Luxembourg.Text" sil:dynamic="true">
         <source xml:lang="en">Luxembourg</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Luxembourg.Text</note>
         <target xml:lang="es-ES" state="translated">Luxemburgo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Luxembourg.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Macau.Text" sil:dynamic="true">
         <source xml:lang="en">Macau</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Macau.Text</note>
         <target xml:lang="es-ES" state="translated">Macao</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Macau.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Macedonia.Text" sil:dynamic="true">
         <source xml:lang="en">Macedonia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Macedonia.Text</note>
         <target xml:lang="es-ES" state="translated">Macedonia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Macedonia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Madagascar.Text" sil:dynamic="true">
         <source xml:lang="en">Madagascar</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Madagascar.Text</note>
         <target xml:lang="es-ES" state="translated">Madagascar</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Madagascar.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Malawi.Text" sil:dynamic="true">
         <source xml:lang="en">Malawi</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Malawi.Text</note>
         <target xml:lang="es-ES" state="translated">Malawi</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Malawi.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Malaysia.Text" sil:dynamic="true">
         <source xml:lang="en">Malaysia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Malaysia.Text</note>
         <target xml:lang="es-ES" state="translated">Malasia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Malaysia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Maldives.Text" sil:dynamic="true">
         <source xml:lang="en">Maldives</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Maldives.Text</note>
         <target xml:lang="es-ES" state="translated">Maldivas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Maldives.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Mali.Text" sil:dynamic="true">
         <source xml:lang="en">Mali</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Mali.Text</note>
         <target xml:lang="es-ES" state="translated">Malí</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Mali.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Malta.Text" sil:dynamic="true">
         <source xml:lang="en">Malta</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Malta.Text</note>
         <target xml:lang="es-ES" state="translated">Malta</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Malta.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Man Isle of.Text" sil:dynamic="true">
         <source xml:lang="en">Man Isle of</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Man Isle of.Text</note>
         <target xml:lang="es-ES" state="translated">Isla de Man</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Man Isle of.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Marshall Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Marshall Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Marshall Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Marshall</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Marshall Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Martinique.Text" sil:dynamic="true">
         <source xml:lang="en">Martinique</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Martinique.Text</note>
         <target xml:lang="es-ES" state="translated">Martinica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Martinique.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Mauritania.Text" sil:dynamic="true">
         <source xml:lang="en">Mauritania</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Mauritania.Text</note>
         <target xml:lang="es-ES" state="translated">Mauritania</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Mauritania.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Mauritius.Text" sil:dynamic="true">
         <source xml:lang="en">Mauritius</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Mauritius.Text</note>
         <target xml:lang="es-ES" state="translated">Mauricio</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Mauritius.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Mayotte.Text" sil:dynamic="true">
         <source xml:lang="en">Mayotte</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Mayotte.Text</note>
         <target xml:lang="es-ES" state="translated">Mayotte</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Mayotte.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Mexico.Text" sil:dynamic="true">
         <source xml:lang="en">Mexico</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Mexico.Text</note>
         <target xml:lang="es-ES" state="translated">México</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Mexico.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Micronesia.Text" sil:dynamic="true">
         <source xml:lang="en">Micronesia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Micronesia.Text</note>
         <target xml:lang="es-ES" state="translated">Micronesia, Estados Federados de</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Micronesia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Moldova.Text" sil:dynamic="true">
         <source xml:lang="en">Moldova</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Moldova.Text</note>
         <target xml:lang="es-ES" state="translated">Moldavia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Moldova.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Monaco.Text" sil:dynamic="true">
         <source xml:lang="en">Monaco</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Monaco.Text</note>
         <target xml:lang="es-ES" state="translated">Mónaco</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Monaco.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Mongolia.Text" sil:dynamic="true">
         <source xml:lang="en">Mongolia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Mongolia.Text</note>
         <target xml:lang="es-ES" state="translated">Mongolia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Mongolia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Montserrat.Text" sil:dynamic="true">
         <source xml:lang="en">Montserrat</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Montserrat.Text</note>
         <target xml:lang="es-ES" state="translated">Montserrat, Isla de</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Montserrat.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Morocco.Text" sil:dynamic="true">
         <source xml:lang="en">Morocco</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Morocco.Text</note>
         <target xml:lang="es-ES" state="translated">Marruecos</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Morocco.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Mozambique.Text" sil:dynamic="true">
         <source xml:lang="en">Mozambique</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Mozambique.Text</note>
         <target xml:lang="es-ES" state="translated">Mozambique</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Mozambique.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Namibia.Text" sil:dynamic="true">
         <source xml:lang="en">Namibia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Namibia.Text</note>
         <target xml:lang="es-ES" state="translated">Namibia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Namibia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Nauru.Text" sil:dynamic="true">
         <source xml:lang="en">Nauru</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Nauru.Text</note>
         <target xml:lang="es-ES" state="translated">Nauru</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Nauru.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Navassa Island.Text" sil:dynamic="true">
         <source xml:lang="en">Navassa Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Navassa Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla de Navaza</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Navassa Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Nepal.Text" sil:dynamic="true">
         <source xml:lang="en">Nepal</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Nepal.Text</note>
         <target xml:lang="es-ES" state="translated">Nepal</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Nepal.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Netherlands Antilles.Text" sil:dynamic="true">
         <source xml:lang="en">Netherlands Antilles</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Netherlands Antilles.Text</note>
         <target xml:lang="es-ES" state="translated">Antillas Holandesas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Netherlands Antilles.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Netherlands.Text" sil:dynamic="true">
         <source xml:lang="en">Netherlands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Netherlands.Text</note>
         <target xml:lang="es-ES" state="translated">Países Bajos, Holanda</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Netherlands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.New Caledonia.Text" sil:dynamic="true">
         <source xml:lang="en">New Caledonia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.New Caledonia.Text</note>
         <target xml:lang="es-ES" state="translated">Nueva Caledonia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.New Caledonia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.New Zealand.Text" sil:dynamic="true">
         <source xml:lang="en">New Zealand</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.New Zealand.Text</note>
         <target xml:lang="es-ES" state="translated">Nueva Zelanda</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.New Zealand.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Nicaragua.Text" sil:dynamic="true">
         <source xml:lang="en">Nicaragua</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Nicaragua.Text</note>
         <target xml:lang="es-ES" state="translated">Nicaragua</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Nicaragua.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Niger.Text" sil:dynamic="true">
         <source xml:lang="en">Niger</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Niger.Text</note>
         <target xml:lang="es-ES" state="translated">Niger</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Niger.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Nigeria.Text" sil:dynamic="true">
         <source xml:lang="en">Nigeria</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Nigeria.Text</note>
         <target xml:lang="es-ES" state="translated">Nigeria</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Nigeria.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Niue.Text" sil:dynamic="true">
         <source xml:lang="en">Niue</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Niue.Text</note>
         <target xml:lang="es-ES" state="translated">Niue</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Niue.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Norfolk Island.Text" sil:dynamic="true">
         <source xml:lang="en">Norfolk Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Norfolk Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Norfolk</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Norfolk Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Northern Mariana Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Northern Mariana Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Northern Mariana Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Marianas del Norte</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Northern Mariana Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Norway.Text" sil:dynamic="true">
         <source xml:lang="en">Norway</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Norway.Text</note>
         <target xml:lang="es-ES" state="translated">Noruega</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Norway.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Oman.Text" sil:dynamic="true">
         <source xml:lang="en">Oman</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Oman.Text</note>
         <target xml:lang="es-ES" state="translated">Omán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Oman.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Pacific Ocean.Text" sil:dynamic="true">
         <source xml:lang="en">Pacific Ocean</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Pacific Ocean.Text</note>
         <target xml:lang="es-ES" state="translated">Océano Pacífico</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Pacific Ocean.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Pakistan.Text" sil:dynamic="true">
         <source xml:lang="en">Pakistan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Pakistan.Text</note>
         <target xml:lang="es-ES" state="translated">Pakistán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Pakistan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Palau.Text" sil:dynamic="true">
         <source xml:lang="en">Palau</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Palau.Text</note>
         <target xml:lang="es-ES" state="translated">Palau</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Palau.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Palmyra Atoll.Text" sil:dynamic="true">
         <source xml:lang="en">Palmyra Atoll</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Palmyra Atoll.Text</note>
         <target xml:lang="es-ES" state="translated">Atolón Palmyra</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Palmyra Atoll.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Panama.Text" sil:dynamic="true">
         <source xml:lang="en">Panama</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Panama.Text</note>
         <target xml:lang="es-ES" state="translated">Panamá</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Panama.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Papua New Guinea.Text" sil:dynamic="true">
         <source xml:lang="en">Papua New Guinea</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Papua New Guinea.Text</note>
         <target xml:lang="es-ES" state="translated">Papúa-Nueva Guinea</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Papua New Guinea.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Paracel Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Paracel Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Paracel Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Paracelso</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Paracel Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Paraguay.Text" sil:dynamic="true">
         <source xml:lang="en">Paraguay</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Paraguay.Text</note>
         <target xml:lang="es-ES" state="translated">Paraguay</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Paraguay.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Peru.Text" sil:dynamic="true">
         <source xml:lang="en">Peru</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Peru.Text</note>
         <target xml:lang="es-ES" state="translated">Perú</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Peru.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Philippines.Text" sil:dynamic="true">
         <source xml:lang="en">Philippines</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Philippines.Text</note>
         <target xml:lang="es-ES" state="translated">Filipinas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Philippines.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Pitcairn Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Pitcairn Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Pitcairn Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Pitcairn</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Pitcairn Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Poland.Text" sil:dynamic="true">
         <source xml:lang="en">Poland</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Poland.Text</note>
         <target xml:lang="es-ES" state="translated">Polonia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Poland.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Portugal.Text" sil:dynamic="true">
         <source xml:lang="en">Portugal</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Portugal.Text</note>
         <target xml:lang="es-ES" state="translated">Portugal</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Portugal.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Puerto Rico.Text" sil:dynamic="true">
         <source xml:lang="en">Puerto Rico</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Puerto Rico.Text</note>
         <target xml:lang="es-ES" state="translated">Puerto Rico</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Puerto Rico.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Qatar.Text" sil:dynamic="true">
         <source xml:lang="en">Qatar</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Qatar.Text</note>
         <target xml:lang="es-ES" state="translated">Qatar</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Qatar.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Reunion.Text" sil:dynamic="true">
         <source xml:lang="en">Reunion</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Reunion.Text</note>
         <target xml:lang="es-ES" state="translated">Reunión</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Reunion.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Romania.Text" sil:dynamic="true">
         <source xml:lang="en">Romania</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Romania.Text</note>
         <target xml:lang="es-ES" state="translated">Rumanía</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Romania.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Russian Federation.Text" sil:dynamic="true">
         <source xml:lang="en">Russian Federation</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Russian Federation.Text</note>
         <target xml:lang="es-ES" state="translated">Federación Rusa</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Russian Federation.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Rwanda.Text" sil:dynamic="true">
         <source xml:lang="en">Rwanda</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Rwanda.Text</note>
         <target xml:lang="es-ES" state="translated">Ruanda</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Rwanda.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Saint Helena.Text" sil:dynamic="true">
         <source xml:lang="en">Saint Helena</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Helena.Text</note>
         <target xml:lang="es-ES" state="translated">Santa Elena</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Helena.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Saint Kitts and Nevis.Text" sil:dynamic="true">
         <source xml:lang="en">Saint Kitts and Nevis</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Kitts and Nevis.Text</note>
         <target xml:lang="es-ES" state="translated">San Cristobal y Nevis</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Kitts and Nevis.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Saint Lucia.Text" sil:dynamic="true">
         <source xml:lang="en">Saint Lucia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Lucia.Text</note>
         <target xml:lang="es-ES" state="translated">Santa Lucía</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Lucia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Saint Pierre and Miquelon.Text" sil:dynamic="true">
         <source xml:lang="en">Saint Pierre and Miquelon</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Pierre and Miquelon.Text</note>
         <target xml:lang="es-ES" state="translated">San Pedro y Miquelón</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Pierre and Miquelon.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Saint Vincent and the Grenadines.Text" sil:dynamic="true">
         <source xml:lang="en">Saint Vincent and the Grenadines</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Vincent and the Grenadines.Text</note>
         <target xml:lang="es-ES" state="translated">San Vincente y Granadinas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Saint Vincent and the Grenadines.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Samoa.Text" sil:dynamic="true">
         <source xml:lang="en">Samoa</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Samoa.Text</note>
         <target xml:lang="es-ES" state="translated">Samoa</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Samoa.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.San Marino.Text" sil:dynamic="true">
         <source xml:lang="en">San Marino</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.San Marino.Text</note>
         <target xml:lang="es-ES" state="translated">San Marino</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.San Marino.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Sao Tome and Principe.Text" sil:dynamic="true">
         <source xml:lang="en">Sao Tome and Principe</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Sao Tome and Principe.Text</note>
         <target xml:lang="es-ES" state="translated">Santo Tomé y Príncipe</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Sao Tome and Principe.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Saudi Arabia.Text" sil:dynamic="true">
         <source xml:lang="en">Saudi Arabia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Saudi Arabia.Text</note>
         <target xml:lang="es-ES" state="translated">Arabia Saudita</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Saudi Arabia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Senegal.Text" sil:dynamic="true">
         <source xml:lang="en">Senegal</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Senegal.Text</note>
         <target xml:lang="es-ES" state="translated">Senegal</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Senegal.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Serbia and Montenegro.Text" sil:dynamic="true">
         <source xml:lang="en">Serbia and Montenegro</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Serbia and Montenegro.Text</note>
         <target xml:lang="es-ES" state="translated">Serbia y Montenegro</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Serbia and Montenegro.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Seychelles.Text" sil:dynamic="true">
         <source xml:lang="en">Seychelles</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Seychelles.Text</note>
         <target xml:lang="es-ES" state="translated">Seychelles</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Seychelles.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Sierra Leone.Text" sil:dynamic="true">
         <source xml:lang="en">Sierra Leone</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Sierra Leone.Text</note>
         <target xml:lang="es-ES" state="translated">Sierra Leona</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Sierra Leone.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Singapore.Text" sil:dynamic="true">
         <source xml:lang="en">Singapore</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Singapore.Text</note>
         <target xml:lang="es-ES" state="translated">Singapur</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Singapore.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Slovak Republic.Text" sil:dynamic="true">
         <source xml:lang="en">Slovak Republic</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Slovak Republic.Text</note>
         <target xml:lang="es-ES" state="translated">Eslovaquia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Slovak Republic.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Slovenia.Text" sil:dynamic="true">
         <source xml:lang="en">Slovenia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Slovenia.Text</note>
         <target xml:lang="es-ES" state="translated">Eslovenia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Slovenia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Solomon Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Solomon Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Solomon Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Salomón</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Solomon Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Somalia.Text" sil:dynamic="true">
         <source xml:lang="en">Somalia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Somalia.Text</note>
         <target xml:lang="es-ES" state="translated">Somalia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Somalia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.South Africa.Text" sil:dynamic="true">
         <source xml:lang="en">South Africa</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.South Africa.Text</note>
         <target xml:lang="es-ES" state="translated">Sudáfrica</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.South Africa.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.South Georgia and the South Sandwich Islands.Text" sil:dynamic="true">
         <source xml:lang="en">South Georgia and the South Sandwich Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.South Georgia and the South Sandwich Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Georgia del Sur e Islas Sandwich del Sur</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.South Georgia and the South Sandwich Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Southern Ocean.Text" sil:dynamic="true">
         <source xml:lang="en">Southern Ocean</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Southern Ocean.Text</note>
         <target xml:lang="es-ES" state="translated">Océano Austral</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Southern Ocean.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Spain.Text" sil:dynamic="true">
         <source xml:lang="en">Spain</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Spain.Text</note>
         <target xml:lang="es-ES" state="translated">España</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Spain.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Spratly Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Spratly Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Spratly Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Spratly</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Spratly Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Sri Lanka.Text" sil:dynamic="true">
         <source xml:lang="en">Sri Lanka</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Sri Lanka.Text</note>
         <target xml:lang="es-ES" state="translated">Sri Lanka</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Sri Lanka.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Sudan.Text" sil:dynamic="true">
         <source xml:lang="en">Sudan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Sudan.Text</note>
         <target xml:lang="es-ES" state="translated">Sudán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Sudan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Suriname.Text" sil:dynamic="true">
         <source xml:lang="en">Suriname</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Suriname.Text</note>
         <target xml:lang="es-ES" state="translated">Surinam</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Suriname.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Svalbard.Text" sil:dynamic="true">
         <source xml:lang="en">Svalbard</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Svalbard.Text</note>
         <target xml:lang="es-ES" state="translated">Svalbard</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Svalbard.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Swaziland.Text" sil:dynamic="true">
         <source xml:lang="en">Swaziland</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Swaziland.Text</note>
         <target xml:lang="es-ES" state="translated">Swazilandia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Swaziland.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Sweden.Text" sil:dynamic="true">
         <source xml:lang="en">Sweden</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Sweden.Text</note>
         <target xml:lang="es-ES" state="translated">Suecia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Sweden.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Switzerland.Text" sil:dynamic="true">
         <source xml:lang="en">Switzerland</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Switzerland.Text</note>
         <target xml:lang="es-ES" state="translated">Suiza</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Switzerland.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Syria.Text" sil:dynamic="true">
         <source xml:lang="en">Syria</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Syria.Text</note>
         <target xml:lang="es-ES" state="translated">Siria</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Syria.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Taiwan.Text" sil:dynamic="true">
         <source xml:lang="en">Taiwan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Taiwan.Text</note>
         <target xml:lang="es-ES" state="translated">Taiwan</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Taiwan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Tajikistan.Text" sil:dynamic="true">
         <source xml:lang="en">Tajikistan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Tajikistan.Text</note>
         <target xml:lang="es-ES" state="translated">Tadjikistan</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Tajikistan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Tanzania.Text" sil:dynamic="true">
         <source xml:lang="en">Tanzania</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Tanzania.Text</note>
         <target xml:lang="es-ES" state="translated">Tanzania</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Tanzania.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Thailand.Text" sil:dynamic="true">
         <source xml:lang="en">Thailand</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Thailand.Text</note>
         <target xml:lang="es-ES" state="translated">Tailandia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Thailand.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.The Gaza Strip.Text" sil:dynamic="true">
         <source xml:lang="en">The Gaza Strip</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.The Gaza Strip.Text</note>
         <target xml:lang="es-ES" state="translated">La Franja de Gaza</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.The Gaza Strip.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Togo.Text" sil:dynamic="true">
         <source xml:lang="en">Togo</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Togo.Text</note>
         <target xml:lang="es-ES" state="translated">Togo</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Togo.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Tokelau.Text" sil:dynamic="true">
         <source xml:lang="en">Tokelau</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Tokelau.Text</note>
         <target xml:lang="es-ES" state="translated">Tokelau</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Tokelau.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Tonga.Text" sil:dynamic="true">
         <source xml:lang="en">Tonga</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Tonga.Text</note>
         <target xml:lang="es-ES" state="translated">Tonga</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Tonga.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Trinidad and Tobago.Text" sil:dynamic="true">
         <source xml:lang="en">Trinidad and Tobago</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Trinidad and Tobago.Text</note>
         <target xml:lang="es-ES" state="translated">Trinidad y Tobago</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Trinidad and Tobago.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Tromolin Island.Text" sil:dynamic="true">
         <source xml:lang="en">Tromolin Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Tromolin Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Tromelin</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Tromolin Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Tunisia.Text" sil:dynamic="true">
         <source xml:lang="en">Tunisia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Tunisia.Text</note>
         <target xml:lang="es-ES" state="translated">Túnez</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Tunisia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Turkey.Text" sil:dynamic="true">
         <source xml:lang="en">Turkey</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Turkey.Text</note>
         <target xml:lang="es-ES" state="translated">Turquía</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Turkey.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Turkmenistan.Text" sil:dynamic="true">
         <source xml:lang="en">Turkmenistan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Turkmenistan.Text</note>
         <target xml:lang="es-ES" state="translated">Turkmenistan</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Turkmenistan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Turks and Caicos Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Turks and Caicos Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Turks and Caicos Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Islas Turcas y Caicos</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Turks and Caicos Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Tuvalu.Text" sil:dynamic="true">
         <source xml:lang="en">Tuvalu</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Tuvalu.Text</note>
         <target xml:lang="es-ES" state="translated">Tuvalu</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Tuvalu.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Uganda.Text" sil:dynamic="true">
         <source xml:lang="en">Uganda</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Uganda.Text</note>
         <target xml:lang="es-ES" state="translated">Uganda</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Uganda.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Ukraine.Text" sil:dynamic="true">
         <source xml:lang="en">Ukraine</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Ukraine.Text</note>
         <target xml:lang="es-ES" state="translated">Ucrania</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Ukraine.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.United Arab Emirates.Text" sil:dynamic="true">
         <source xml:lang="en">United Arab Emirates</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.United Arab Emirates.Text</note>
         <target xml:lang="es-ES" state="translated">Emiratos Árabes Unidos</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.United Arab Emirates.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.United Kingdom.Text" sil:dynamic="true">
         <source xml:lang="en">United Kingdom</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.United Kingdom.Text</note>
         <target xml:lang="es-ES" state="translated">Reino Unido</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.United Kingdom.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.United States.Text" sil:dynamic="true">
         <source xml:lang="en">United States</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.United States.Text</note>
         <target xml:lang="es-ES" state="translated">Estados Unidos</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.United States.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Uruguay.Text" sil:dynamic="true">
         <source xml:lang="en">Uruguay</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Uruguay.Text</note>
         <target xml:lang="es-ES" state="translated">Uruguay</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Uruguay.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Uzbekistan.Text" sil:dynamic="true">
         <source xml:lang="en">Uzbekistan</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Uzbekistan.Text</note>
         <target xml:lang="es-ES" state="translated">Uzbekistán</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Uzbekistan.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Vanuatu.Text" sil:dynamic="true">
         <source xml:lang="en">Vanuatu</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Vanuatu.Text</note>
         <target xml:lang="es-ES" state="translated">Vanuatu</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Vanuatu.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Venezuela.Text" sil:dynamic="true">
         <source xml:lang="en">Venezuela</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Venezuela.Text</note>
         <target xml:lang="es-ES" state="translated">Venezuela</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Venezuela.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Vietnam.Text" sil:dynamic="true">
         <source xml:lang="en">Vietnam</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Vietnam.Text</note>
         <target xml:lang="es-ES" state="translated">Vietnam</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Vietnam.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Virgin Islands (US).Text" sil:dynamic="true">
         <source xml:lang="en">Virgin Islands (US)</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Virgin Islands (US).Text</note>
         <target xml:lang="es-ES" state="translated">Islas Virgenes Americanas</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Virgin Islands (US).Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Wake Island.Text" sil:dynamic="true">
         <source xml:lang="en">Wake Island</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Wake Island.Text</note>
         <target xml:lang="es-ES" state="translated">Isla Wake</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Wake Island.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Wallis and Futuna Islands.Text" sil:dynamic="true">
         <source xml:lang="en">Wallis and Futuna Islands</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Wallis and Futuna Islands.Text</note>
         <target xml:lang="es-ES" state="translated">Wallis y Futuna</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Wallis and Futuna Islands.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.West Bank.Text" sil:dynamic="true">
         <source xml:lang="en">West Bank</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.West Bank.Text</note>
         <target xml:lang="es-ES" state="translated">Cisjordania (Ribera Occidental)</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.West Bank.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Western Sahara.Text" sil:dynamic="true">
         <source xml:lang="en">Western Sahara</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Western Sahara.Text</note>
         <target xml:lang="es-ES" state="translated">Sáhara Occidental</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Western Sahara.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Yemen.Text" sil:dynamic="true">
         <source xml:lang="en">Yemen</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Yemen.Text</note>
         <target xml:lang="es-ES" state="translated">Yemen</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Yemen.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Zambia.Text" sil:dynamic="true">
         <source xml:lang="en">Zambia</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Zambia.Text</note>
         <target xml:lang="es-ES" state="translated">Zambia</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Zambia.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.ListItems.Countries.Zimbabwe.Text" sil:dynamic="true">
         <source xml:lang="en">Zimbabwe</source>
-        <note>ID: CommonToMultipleViews.ListItems.Countries.Zimbabwe.Text</note>
         <target xml:lang="es-ES" state="translated">Zimbabwe</target>
+        <note>ID: CommonToMultipleViews.ListItems.Countries.Zimbabwe.Text</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.InvalidMediaFile">
         <source xml:lang="en">File does not appear to be a valid media file: {0}</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.InvalidMediaFile</note>
         <target xml:lang="es-ES" state="translated">Archivo no parece ser un archivo multimedia válido: {0}</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.InvalidMediaFile</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.MediaFileNotFoundMsg">
         <source xml:lang="en">Media file not found: {0}</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.MediaFileNotFoundMsg</note>
         <target xml:lang="es-ES" state="translated">Archivo multimedia no se encuentra: '{0}'</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.MediaFileNotFoundMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.MediaFileNotSpecifiedMsg">
         <source xml:lang="en">Media player file name has not been specified.</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.MediaFileNotSpecifiedMsg</note>
         <target xml:lang="es-ES" state="translated">No se ha especificado el nombre de archivo que desea reproducir.</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.MediaFileNotSpecifiedMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.PauseButton">
         <source xml:lang="en">Pause</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.PauseButton</note>
         <target xml:lang="es-ES" state="translated">Pausa</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.PauseButton</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.PauseButton_ToolTip_">
         <source xml:lang="en">Pause</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.PauseButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Pausa</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.PauseButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.PlayButton">
         <source xml:lang="en">Play</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.PlayButton</note>
         <target xml:lang="es-ES" state="translated">Reproducir</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.PlayButton</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.PlayButton_ToolTip_">
         <source xml:lang="en">Play</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.PlayButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Reproducir</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.PlayButton_ToolTip_</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.MediaPlayer.ProbablyCannotLoad">
+        <source xml:lang="en">Media player will probably not be able to load this file.</source>
+        <target xml:lang="es-ES" state="translated">Probablemente el reproductor multimedia no podrá cargar este archivo.</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.ProbablyCannotLoad</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.StopButton">
         <source xml:lang="en">Stop</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.StopButton</note>
         <target xml:lang="es-ES" state="translated">Parar</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.StopButton</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.StopButton_ToolTip_">
         <source xml:lang="en">Stop</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.StopButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Parar</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.StopButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.TabText-Audio">
         <source xml:lang="en">Audio</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.TabText-Audio</note>
         <target xml:lang="es-ES" state="translated">Audio</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.TabText-Audio</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.TabText-Video">
         <source xml:lang="en">Video</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.TabText-Video</note>
         <target xml:lang="es-ES" state="translated">Video</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.TabText-Video</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.TimeCurrentOfTotalDisplayFormat">
         <source xml:lang="en">{0} / {1}</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.TimeCurrentOfTotalDisplayFormat</note>
         <target xml:lang="es-ES" state="translated">{0} / {1}</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.TimeCurrentOfTotalDisplayFormat</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.TimeRangeDisplayFormat">
         <source xml:lang="en">{0} - {1}</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.TimeRangeDisplayFormat</note>
         <target xml:lang="es-ES" state="translated">{0} - {1}</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.TimeRangeDisplayFormat</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.UnableToStartMplayerProcessMsg">
         <source xml:lang="en">Unable to start mplayer.</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.UnableToStartMplayerProcessMsg</note>
         <target xml:lang="es-ES" state="translated">No se pudo iniciar mplayer.</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.UnableToStartMplayerProcessMsg</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.VolumeButton">
         <source xml:lang="en">Volume</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.VolumeButton</note>
         <target xml:lang="es-ES" state="translated">Volumen</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.VolumeButton</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPlayer.VolumeButton_ToolTip_">
         <source xml:lang="en">Volume</source>
-        <note>ID: CommonToMultipleViews.MediaPlayer.VolumeButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Volumen</target>
+        <note>ID: CommonToMultipleViews.MediaPlayer.VolumeButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPropertiesEditor.MoreInfoButton">
         <source xml:lang="en">More Information...</source>
-        <note>ID: CommonToMultipleViews.MediaPropertiesEditor.MoreInfoButton</note>
         <target xml:lang="es-ES" state="translated">Más información...</target>
+        <note>ID: CommonToMultipleViews.MediaPropertiesEditor.MoreInfoButton</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPropertiesEditor.MoreInfoButton_ToolTip_">
         <source xml:lang="en">More information about this file</source>
-        <note>ID: CommonToMultipleViews.MediaPropertiesEditor.MoreInfoButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Más información sobre este archivo</target>
+        <note>ID: CommonToMultipleViews.MediaPropertiesEditor.MoreInfoButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPropertiesEditor.PresetsButton">
         <source xml:lang="en">Presets</source>
-        <note>ID: CommonToMultipleViews.MediaPropertiesEditor.PresetsButton</note>
         <target xml:lang="es-ES" state="translated">Ajustes preestablecidos</target>
+        <note>ID: CommonToMultipleViews.MediaPropertiesEditor.PresetsButton</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.MediaPropertiesEditor.PresetsButton_ToolTip_">
         <source xml:lang="en">Select presets for media file</source>
-        <note>ID: CommonToMultipleViews.MediaPropertiesEditor.PresetsButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Seleccionar ajustes preestablecidos para archivo multimedio</target>
+        <note>ID: CommonToMultipleViews.MediaPropertiesEditor.PresetsButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.NotesEditor.TabText">
         <source xml:lang="en">Notes</source>
-        <note>ID: CommonToMultipleViews.NotesEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Notas</target>
+        <note>ID: CommonToMultipleViews.NotesEditor.TabText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.PercentFormat">
         <source xml:lang="en">{0}%</source>
-        <note>ID: CommonToMultipleViews.PercentFormat</note>
         <target xml:lang="es-ES" state="translated">{0} %</target>
+        <note>ID: CommonToMultipleViews.PercentFormat</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.PropertiesEditor.TabText">
         <source xml:lang="en">Properties</source>
-        <note>ID: CommonToMultipleViews.PropertiesEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Propiedades</target>
+        <note>ID: CommonToMultipleViews.PropertiesEditor.TabText</note>
       </trans-unit>
       <trans-unit id="CommonToMultipleViews.TextFileDescriptor">
         <source xml:lang="en">Text File ({0})</source>
-        <note>ID: CommonToMultipleViews.TextFileDescriptor</note>
         <target xml:lang="es-ES" state="translated">archivo de texto ({0})</target>
+        <note>ID: CommonToMultipleViews.TextFileDescriptor</note>
+      </trans-unit>
+      <trans-unit id="CommonToMultipleViews.UnableToObtainShortName">
+        <source xml:lang="en">{0} was unable to obtain a "short name" for this file:\n{1}\nYou (or a system administrator) can use {2} to enable creation of short "8.3" file names for the file system volume ({3}) where this file is located.</source>
+        <target xml:lang="es-ES" state="needs-translation">{0} was unable to obtain a "short name" for this file:\n{1}\nYou (or a system administrator) can use {2} to enable creation of short "8.3" file names for the file system volume ({3}) where this file is located.</target>
+        <note>ID: CommonToMultipleViews.UnableToObtainShortName</note>
       </trans-unit>
       <trans-unit id="ConvertMedia.FullConversionOutput">
         <source xml:lang="en">Full output from conversion:</source>
-        <note>ID: ConvertMedia.FullConversionOutput</note>
         <target xml:lang="es-ES" state="translated">Salida completa de conversión:</target>
+        <note>ID: ConvertMedia.FullConversionOutput</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.AddingContributorFilesProgressMsg">
         <source xml:lang="en">Adding Files for Contributor '{0}'</source>
-        <note>ID: DialogBoxes.ArchivingDlg.AddingContributorFilesProgressMsg</note>
         <target xml:lang="es-ES" state="translated">Agregando archivos al colaborador '{0}'</target>
+        <note>ID: DialogBoxes.ArchivingDlg.AddingContributorFilesProgressMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.AddingContributorFilesToIMDIArchiveProgressMsg">
         <source xml:lang="en">Adding Files for Contributors...</source>
-        <note>ID: DialogBoxes.ArchivingDlg.AddingContributorFilesToIMDIArchiveProgressMsg</note>
         <target xml:lang="es-ES" state="translated">Añadiendo los archivos de los contribuyentes...</target>
+        <note>ID: DialogBoxes.ArchivingDlg.AddingContributorFilesToIMDIArchiveProgressMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.AddingOtherProjectDocumentsToIMDIArchiveProgressMsg">
         <source xml:lang="en">Adding Other Project Documents...</source>
-        <note>ID: DialogBoxes.ArchivingDlg.AddingOtherProjectDocumentsToIMDIArchiveProgressMsg</note>
         <target xml:lang="es-ES" state="translated">Agregando otros documentos del proyecto...</target>
+        <note>ID: DialogBoxes.ArchivingDlg.AddingOtherProjectDocumentsToIMDIArchiveProgressMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.AddingProjectDescriptionDocumentsToIMDIArchiveProgressMsg">
         <source xml:lang="en">Adding Project Description Documents...</source>
-        <note>ID: DialogBoxes.ArchivingDlg.AddingProjectDescriptionDocumentsToIMDIArchiveProgressMsg</note>
         <target xml:lang="es-ES" state="translated">Agregando documentos descriptivos de proyecto...</target>
+        <note>ID: DialogBoxes.ArchivingDlg.AddingProjectDescriptionDocumentsToIMDIArchiveProgressMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.AddingSessionFilesProgressMsg">
         <source xml:lang="en">Adding Files for Session '{0}'</source>
-        <note>ID: DialogBoxes.ArchivingDlg.AddingSessionFilesProgressMsg</note>
         <target xml:lang="es-ES" state="translated">Agregando archivos a la sesión '{0}'</target>
+        <note>ID: DialogBoxes.ArchivingDlg.AddingSessionFilesProgressMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.ArchivingInfoDetails">
         <source xml:lang="en">The archive package will include all required files and data related to a session and its contributors.</source>
-        <note>ID: DialogBoxes.ArchivingDlg.ArchivingInfoDetails</note>
-        <note>This sentence is inserted as a parameter in DialogBoxes.ArchivingDlg.xxxxOverviewText</note>
         <target xml:lang="es-ES" state="translated">Reunirá todos los archivos y datos relacionados con ua sesión y sus colaboradores.</target>
+        <note>ID: DialogBoxes.ArchivingDlg.ArchivingInfoDetails</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.ArchivingProgressMsg">
         <source xml:lang="en">     {0}: {1}</source>
-        <note>ID: DialogBoxes.ArchivingDlg.ArchivingProgressMsg</note>
-        <note>The first parameter is 'Session' or 'Contributor'. The second parameter is the session or contributor name.</note>
         <target xml:lang="es-ES" state="needs-translation">     {0}: {1}</target>
+        <note>ID: DialogBoxes.ArchivingDlg.ArchivingProgressMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.ContributorElementName">
         <source xml:lang="en">Contributor</source>
-        <note>ID: DialogBoxes.ArchivingDlg.ContributorElementName</note>
         <target xml:lang="es-ES" state="translated">Contribuyente</target>
+        <note>ID: DialogBoxes.ArchivingDlg.ContributorElementName</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.InvalidAgeMsg">
         <source xml:lang="en">The age for {0} must be between 2 and 130</source>
-        <note>ID: DialogBoxes.ArchivingDlg.InvalidAgeMsg</note>
         <target xml:lang="es-ES" state="translated">La edad para {0} debe estar entre 2 y 130 años.</target>
+        <note>ID: DialogBoxes.ArchivingDlg.InvalidAgeMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.InvalidBirthYearMsg">
         <source xml:lang="en">The Birth Year for {0} should be a 4 digit number. It is used to calculate the age for the IMDI export.</source>
-        <note>ID: DialogBoxes.ArchivingDlg.InvalidBirthYearMsg</note>
         <target xml:lang="es-ES" state="translated">El año del nacimiento de {0} debe ser un número de 4 dígitos o dejarse en blanco.</target>
+        <note>ID: DialogBoxes.ArchivingDlg.InvalidBirthYearMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.NoContributorsForSessionMsg">
         <source xml:lang="en">There are no contributors for this session.</source>
-        <note>ID: DialogBoxes.ArchivingDlg.NoContributorsForSessionMsg</note>
         <target xml:lang="es-ES" state="translated">No hay ningún colaborador para esta sesión.</target>
+        <note>ID: DialogBoxes.ArchivingDlg.NoContributorsForSessionMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.PersonNotParticipating">
         <source xml:lang="en">{0} is listed as a contributor but not a participant in {1} session.</source>
-        <note>ID: DialogBoxes.ArchivingDlg.PersonNotParticipating</note>
         <target xml:lang="es-ES" state="translated">{0} está en la lista de colaboradores pero no es participante en la sesión {1}.</target>
+        <note>ID: DialogBoxes.ArchivingDlg.PersonNotParticipating</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.PrearchivingStatusMsg1">
         <source xml:lang="en">The following session and contributor files will be added to your archive.</source>
-        <note>ID: DialogBoxes.ArchivingDlg.PrearchivingStatusMsg1</note>
         <target xml:lang="es-ES" state="translated">Los siguientes archivos de sesión y colaborador se agregarán a la colección permanente de archivos.</target>
+        <note>ID: DialogBoxes.ArchivingDlg.PrearchivingStatusMsg1</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.PrearchivingStatusMsg2">
         <source xml:lang="en">The following session files will be added to your archive.</source>
-        <note>ID: DialogBoxes.ArchivingDlg.PrearchivingStatusMsg2</note>
         <target xml:lang="es-ES" state="translated">Los siguientes archivos de sesión se agregará a la colección permanente de archivos.</target>
+        <note>ID: DialogBoxes.ArchivingDlg.PrearchivingStatusMsg2</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.ProjectArchivingInfoDetails">
         <source xml:lang="en">The archive corpus will include all required files and data related to this project.</source>
-        <note>ID: DialogBoxes.ArchivingDlg.ProjectArchivingInfoDetails</note>
-        <note>This sentence is inserted as a parameter in DialogBoxes.ArchivingDlg.IMDIOverviewText</note>
         <target xml:lang="es-ES" state="translated">El archivo permanente incluirá todos los archivos requeridos y los datos relacionados con este proyecto.</target>
+        <note>ID: DialogBoxes.ArchivingDlg.ProjectArchivingInfoDetails</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ArchivingDlg.SessionElementName">
         <source xml:lang="en">Session</source>
-        <note>ID: DialogBoxes.ArchivingDlg.SessionElementName</note>
         <target xml:lang="es-ES" state="translated">Sesión</target>
+        <note>ID: DialogBoxes.ArchivingDlg.SessionElementName</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentEditors.MediaFileMoreInfoDlg.GettingInfoErrorMsg">
         <source xml:lang="en">There was an error trying to get more information for the media file:\n\n{0}</source>
-        <note>ID: DialogBoxes.ComponentEditors.MediaFileMoreInfoDlg.GettingInfoErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Hubo un error al intentar obtener más información sobre el archivo multimedia:\n\n\n\n{0}</target>
+        <note>ID: DialogBoxes.ComponentEditors.MediaFileMoreInfoDlg.GettingInfoErrorMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg.FileAlreadyExistsMsg">
         <source xml:lang="en">A file by that name already exists or the name is invalid.</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg.FileAlreadyExistsMsg</note>
         <target xml:lang="es-ES" state="translated">Ya existe un archivo con ese nombre, o el nombre no es válido.</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg.FileAlreadyExistsMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg.NewFileNameMsg">
         <source xml:lang="en">New file: {0}</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg.NewFileNameMsg</note>
-        <note>Displayed under the text box.; Parameter is file name.</note>
         <target xml:lang="es-ES" state="translated">Nuevo archivo: {0}</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg.NewFileNameMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg.WindowTitle">
         <source xml:lang="en">Rename</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Cambiar el nombre</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._buttonCancel">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._buttonCancel</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._buttonCancel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._buttonRename">
         <source xml:lang="en">Rename</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._buttonRename</note>
         <target xml:lang="es-ES" state="translated">Cambiar el nombre</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._buttonRename</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._labelChangeNameTo">
         <source xml:lang="en">Change Name To:</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelChangeNameTo</note>
         <target xml:lang="es-ES" state="translated">Cambiar el nombre a:</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelChangeNameTo</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._labelNonSayMoreImportHint">
         <source xml:lang="en">Use the following only when you are importing annotations produced outside of SayMore</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelNonSayMoreImportHint</note>
         <target xml:lang="es-ES" state="translated">Use las siguientes opciones solamente cuando está importando anotaciones producidas fuera de SayMore</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelNonSayMoreImportHint</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._labelReadAboutRenaming">
         <source xml:lang="en">Read About How SayMore Uses Names</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelReadAboutRenaming</note>
         <target xml:lang="es-ES" state="translated">Lea sobre cómo SayMore utiliza nombres</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelReadAboutRenaming</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._labelShortcuts">
         <source xml:lang="en">Shortcuts</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelShortcuts</note>
         <target xml:lang="es-ES" state="translated">Accesos directos</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelShortcuts</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._labelShortcutsHint">
         <source xml:lang="en">(hover over each link to read about how it is used)</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelShortcutsHint</note>
         <target xml:lang="es-ES" state="translated">(pase el ratón sobre cada enlace para obtener información acerca de cómo se utiliza)</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._labelShortcutsHint</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkCareful">
         <source xml:lang="en">Careful Speech</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkCareful</note>
         <target xml:lang="es-ES" state="translated">Habla cuidadosa</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkCareful</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkCareful_ToolTip_">
         <source xml:lang="en">Careful Speech:\nSlow, careful speech re-speaking\nof the source recording.</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkCareful_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Habla cuidadosa:\nGrabación de una reproduccón del discurso original en forma lenta y\ncuidadosa para ayudar al lingüista escuchar distintivamente cada palabra.</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkCareful_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkConsent">
         <source xml:lang="en">Informed Consent</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkConsent</note>
         <target xml:lang="es-ES" state="translated">Consentimiento informado</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkConsent</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkConsent_ToolTip_">
         <source xml:lang="en">Informed Consent:\nA scan or recording of consent covering\nthe use of this person's contribution.</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkConsent_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Consentimiento informado:\nEscaneo o grabación de consentimiento que indica permiso\npara el uso de la contribución de esta persona.</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkConsent_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkOralTranslation">
         <source xml:lang="en">Oral Translation</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkOralTranslation</note>
         <target xml:lang="es-ES" state="translated">Traducción oral</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkOralTranslation</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkOralTranslation_ToolTip_">
         <source xml:lang="en">Oral Translation:\nRecording of a translation\nof the source recording.</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkOralTranslation_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Traducción oral:\nGrabación de una traducción de la grabación\noriginal en el lengua de comunicación más amplia.</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkOralTranslation_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkSource">
         <source xml:lang="en">Source</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkSource</note>
         <target xml:lang="es-ES" state="translated">Original</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkSource</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkSource_ToolTip_">
         <source xml:lang="en">Source:\nThe recording of the session. Used to satisfy\nthe 'Source Recording' stage of the session.</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkSource_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Original:\nLa grabación de la sesión. La presencia de este archivo indica que\nse ha realizado la etapa de 'Grabación original' de la sesión.</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkSource_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkTranscription">
         <source xml:lang="en">Transcription</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkTranscription</note>
         <target xml:lang="es-ES" state="translated">Transcripción</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkTranscription</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkTranscription_ToolTip_">
         <source xml:lang="en">Transcription:\nWritten transcription of\nthe source recording.</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkTranscription_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Transcripción:\nTranscripción escrita de la grabación original.</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkTranscription_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkWrittenTranslation">
         <source xml:lang="en">Written Translation</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkWrittenTranslation</note>
         <target xml:lang="es-ES" state="translated">Traducción escrita</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkWrittenTranslation</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ComponentFileRenamingDlg._linkWrittenTranslation_ToolTip_">
         <source xml:lang="en">Written Translation:\nWritten translation of\nthe source recording.</source>
-        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkWrittenTranslation_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Traducción escrita:\nTraducción escrita de la grabación original en\nel lengua de comunicación más amplia.</target>
+        <note>ID: DialogBoxes.ComponentFileRenamingDlg._linkWrittenTranslation_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.AvailableConversionsLabel">
         <source xml:lang="en">Available Conversions:</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.AvailableConversionsLabel</note>
         <target xml:lang="es-ES" state="translated">Conversiones disponibles:</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.AvailableConversionsLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.BeginConversionButton">
         <source xml:lang="en">Begin Conversion</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.BeginConversionButton</note>
         <target xml:lang="es-ES" state="translated">Iniciar conversión</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.BeginConversionButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.CancelButton">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.CancelButton</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.CancelButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.CloseButton">
         <source xml:lang="en">Close</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.CloseButton</note>
         <target xml:lang="es-ES" state="translated">Cerrar</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.CloseButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ConversionCancelledMsg">
         <source xml:lang="en">Conversion Cancelled.</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionCancelledMsg</note>
         <target xml:lang="es-ES" state="translated">Conversión cancelada.</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionCancelledMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ConversionFailedMsg">
         <source xml:lang="en">Conversion Failed.</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionFailedMsg</note>
         <target xml:lang="es-ES" state="translated">Error de conversión.</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionFailedMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ConversionFinishedWithPossibleErrorsMsg">
         <source xml:lang="en">Conversion Finished, but with possible errors.</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionFinishedWithPossibleErrorsMsg</note>
         <target xml:lang="es-ES" state="translated">La conversión terminó, pero con posibles errores.</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionFinishedWithPossibleErrorsMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ConversionProgressStatusMsgFormat">
         <source xml:lang="en">{0} of {1} Converted...</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionProgressStatusMsgFormat</note>
         <target xml:lang="es-ES" state="translated">{0} de {1} convertido...</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionProgressStatusMsgFormat</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ConversionSucceededMsg">
         <source xml:lang="en">Conversion Finished Successfully.</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionSucceededMsg</note>
         <target xml:lang="es-ES" state="translated">Conversión realizado.</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ConversionSucceededMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ConvertToMp4AndAACConversionName">
         <source xml:lang="en">Convert to H.263/MPEG-4 video with AAC Audio</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ConvertToMp4AndAACConversionName</note>
         <target xml:lang="es-ES" state="translated">Convertir a video H.263/MPEG-4 con Audio AAC</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ConvertToMp4AndAACConversionName</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ExportAudioTitle">
         <source xml:lang="en">Exporting Audio....</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ExportAudioTitle</note>
         <target xml:lang="es-ES" state="translated">Exportando audio…</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ExportAudioTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ExtractStandardPcmFromVideoMenuText">
         <source xml:lang="en">Extract audio to standard WAV PCM audio file</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ExtractStandardPcmFromVideoMenuText</note>
         <target xml:lang="es-ES" state="translated">Extraer audio a un archivo de onda WAV PCM</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ExtractStandardPcmFromVideoMenuText</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.FileToConvertLabel">
         <source xml:lang="en">File to Convert:</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.FileToConvertLabel</note>
         <target xml:lang="es-ES" state="translated">Archivo a convertir:</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.FileToConvertLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.HideOutputButton">
         <source xml:lang="en">Hide Details</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.HideOutputButton</note>
         <target xml:lang="es-ES" state="translated">Ocultar detalles</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.HideOutputButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.InvalidMediaFile">
         <source xml:lang="en">File does not appear to be a valid media file.</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.InvalidMediaFile</note>
         <target xml:lang="es-ES" state="translated">Archivo no parece ser un archivo multimedia válido.</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.InvalidMediaFile</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.OutputFileLabel">
         <source xml:lang="en">Output File:</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.OutputFileLabel</note>
         <target xml:lang="es-ES" state="translated">Archivo de salida:</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.OutputFileLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.OverviewLabel">
         <source xml:lang="en">To convert your media file to a different format, choose from one of the available conversions below and click 'Begin Conversion'. Your source media file will not be affected.</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.OverviewLabel</note>
         <target xml:lang="es-ES" state="translated">Para convertir el archivo multimedia en un formato diferente, elija una de las conversiones disponibles a continuación y haga clic en 'Iniciar conversión'. El archivo original no será afectado.</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.OverviewLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.ShowOutputButton">
         <source xml:lang="en">Show Details</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.ShowOutputButton</note>
         <target xml:lang="es-ES" state="translated">Mostrar detalles</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.ShowOutputButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ConvertMediaDlg.WindowTitle">
         <source xml:lang="en">Convert Media</source>
-        <note>ID: DialogBoxes.ConvertMediaDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Convertir archivo multimedia</target>
+        <note>ID: DialogBoxes.ConvertMediaDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.DeleteMessageBox.WindowTitle">
         <source xml:lang="en">Confirm Delete</source>
-        <note>ID: DialogBoxes.DeleteMessageBox.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Confirmar la eliminación</target>
+        <note>ID: DialogBoxes.DeleteMessageBox.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.DeleteMessageBox._buttonCancel">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.DeleteMessageBox._buttonCancel</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.DeleteMessageBox._buttonCancel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.DeleteMessageBox._buttonDelete">
         <source xml:lang="en">Delete</source>
-        <note>ID: DialogBoxes.DeleteMessageBox._buttonDelete</note>
         <target xml:lang="es-ES" state="translated">Borrar</target>
+        <note>ID: DialogBoxes.DeleteMessageBox._buttonDelete</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.FileLoadErrorsReportDlg.SaveFileDialog.Title">
         <source xml:lang="en">Choose File Location</source>
-        <note>ID: DialogBoxes.FileLoadErrorsReportDlg.SaveFileDialog.Title</note>
         <target xml:lang="es-ES" state="translated">Elejir la carpeta para el archivo</target>
+        <note>ID: DialogBoxes.FileLoadErrorsReportDlg.SaveFileDialog.Title</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.LoadProject.InvalidPath">
         <source xml:lang="en">SayMore is not able to open the project file. "{0}" is not a valid path.</source>
-        <note>ID: DialogBoxes.LoadProject.InvalidPath</note>
         <target xml:lang="es-ES" state="translated">SayMore no puede abrir el proyecto. "{0}" no es una ruta válida.</target>
+        <note>ID: DialogBoxes.LoadProject.InvalidPath</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.LoadingDlg.CancelLink">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.LoadingDlg.CancelLink</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.LoadingDlg.CancelLink</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.LoadingDlg._labelLoading">
         <source xml:lang="en">Loading...</source>
-        <note>ID: DialogBoxes.LoadingDlg._labelLoading</note>
         <target xml:lang="es-ES" state="translated">Cargando...</target>
+        <note>ID: DialogBoxes.LoadingDlg._labelLoading</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.MediaFileMoreInfoDlg.CloseButton">
         <source xml:lang="en">Close</source>
-        <note>ID: DialogBoxes.MediaFileMoreInfoDlg.CloseButton</note>
         <target xml:lang="es-ES" state="translated">Cerrar</target>
+        <note>ID: DialogBoxes.MediaFileMoreInfoDlg.CloseButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.MediaFileMoreInfoDlg.EvenMoreInfoButton">
         <source xml:lang="en">Even More Information</source>
-        <note>ID: DialogBoxes.MediaFileMoreInfoDlg.EvenMoreInfoButton</note>
         <target xml:lang="es-ES" state="translated">Aún más información</target>
+        <note>ID: DialogBoxes.MediaFileMoreInfoDlg.EvenMoreInfoButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.MediaFileMoreInfoDlg.LessInfoButton">
         <source xml:lang="en">Less Information</source>
-        <note>ID: DialogBoxes.MediaFileMoreInfoDlg.LessInfoButton</note>
         <target xml:lang="es-ES" state="translated">Menos información</target>
+        <note>ID: DialogBoxes.MediaFileMoreInfoDlg.LessInfoButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.MediaFileMoreInfoDlg.WindowTitle">
         <source xml:lang="en">More Information for Media File</source>
-        <note>ID: DialogBoxes.MediaFileMoreInfoDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Más información del archivo multimedia</target>
+        <note>ID: DialogBoxes.MediaFileMoreInfoDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewProjectDlg.InvalidPathMsg">
         <source xml:lang="en">Unable to create a new project by that name.</source>
-        <note>ID: DialogBoxes.NewProjectDlg.InvalidPathMsg</note>
-        <note>This text is displayed under the project name when it is invalid.</note>
         <target xml:lang="es-ES" state="translated">No se pudo crear un nuevo proyecto con ese nombre.</target>
+        <note>ID: DialogBoxes.NewProjectDlg.InvalidPathMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewProjectDlg.WindowTitle">
         <source xml:lang="en">New SayMore Project</source>
-        <note>ID: DialogBoxes.NewProjectDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Nuevo proyecto SayMore</target>
+        <note>ID: DialogBoxes.NewProjectDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewProjectDlg._buttonCancel">
         <source xml:lang="en">&amp;Cancel</source>
-        <note>ID: DialogBoxes.NewProjectDlg._buttonCancel</note>
         <target xml:lang="es-ES" state="translated">&amp;Cancelar</target>
+        <note>ID: DialogBoxes.NewProjectDlg._buttonCancel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewProjectDlg._buttonOK">
         <source xml:lang="en">OK</source>
-        <note>ID: DialogBoxes.NewProjectDlg._buttonOK</note>
         <target xml:lang="es-ES" state="translated">Aceptar</target>
+        <note>ID: DialogBoxes.NewProjectDlg._buttonOK</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewProjectDlg._labelMessage">
         <source xml:lang="en">What would you like to call this project?</source>
-        <note>ID: DialogBoxes.NewProjectDlg._labelMessage</note>
         <target xml:lang="es-ES" state="translated">¿Cómo desea llamar este proyecto?</target>
+        <note>ID: DialogBoxes.NewProjectDlg._labelMessage</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewProjectDlg._labelNewProjectPath">
         <source xml:lang="en">Project will be created in: {0}</source>
-        <note>ID: DialogBoxes.NewProjectDlg._labelNewProjectPath</note>
-        <note>This text is displayed under the project name and includes where it will be created.</note>
         <target xml:lang="es-ES" state="translated">Proyecto se creará in: {0}</target>
+        <note>ID: DialogBoxes.NewProjectDlg._labelNewProjectPath</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg.CreatingSessions.ProgressDlg.Caption">
         <source xml:lang="en">Creating Sessions</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.CreatingSessions.ProgressDlg.Caption</note>
         <target xml:lang="es-ES" state="translated">Creando sesiones</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.CreatingSessions.ProgressDlg.Caption</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg.FolderBrowserDlgDescription">
         <source xml:lang="en">Choose a Folder of Media Files.</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.FolderBrowserDlgDescription</note>
         <target xml:lang="es-ES" state="translated">Elija una carpeta de archivos mediales.</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.FolderBrowserDlgDescription</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg.NoFilesSelectedCreateButtonText">
         <source xml:lang="en">Create Sessions</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.NoFilesSelectedCreateButtonText</note>
-        <note>Text in create button when no files are selected.</note>
         <target xml:lang="es-ES" state="translated">Crear sesiones</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.NoFilesSelectedCreateButtonText</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg.OneFileSelectedCreateButtonText">
         <source xml:lang="en">Create 1 Session</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.OneFileSelectedCreateButtonText</note>
-        <note>Text in create button when one file is selected.</note>
         <target xml:lang="es-ES" state="translated">Crear 1 sesión</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.OneFileSelectedCreateButtonText</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg.SessionsAlreadyExistMsg">
         <source xml:lang="en">Sessions already exist for the following Ids. These will be skipped.\n\n{0}</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.SessionsAlreadyExistMsg</note>
         <target xml:lang="es-ES" state="translated">Ya existen sesiones para los siguientes identificadores. Estos se omitirán.\n\n{0}</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.SessionsAlreadyExistMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg.WindowTitle">
         <source xml:lang="en">New Sessions From Device</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Nuevas sesiones de dispositivo</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg._buttonCancel">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._buttonCancel</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._buttonCancel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg._buttonCreateSessions">
         <source xml:lang="en">Create {0} Sessions</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._buttonCreateSessions</note>
-        <note>Format text in create button when more than one file is selected. Parameter is the number of sessions to be created.</note>
         <target xml:lang="es-ES" state="translated">Crear {0} sesiones</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._buttonCreateSessions</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg._labelIncomingFiles">
         <source xml:lang="en">Incoming &amp;Files</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._labelIncomingFiles</note>
         <target xml:lang="es-ES" state="translated">Archivos entrantes</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._labelIncomingFiles</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg._labelInstructions">
         <source xml:lang="en">Mark each file which represents a source recording of a session. For each one, SayMore will create a new session and copy the file into it.</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._labelInstructions</note>
         <target xml:lang="es-ES" state="translated">Seleccione cada archivo que representa una grabación original de una sesión. Para cada uno, SayMore creará una nueva sesión con una cópia del archivo.</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._labelInstructions</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg._labelProgress">
         <source xml:lang="en">Reading Files...</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._labelProgress</note>
         <target xml:lang="es-ES" state="translated">Leyendo archivos...</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._labelProgress</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlg._linkFindFiles">
         <source xml:lang="en">Find Files on Recorder/Card...</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._linkFindFiles</note>
         <target xml:lang="es-ES" state="translated">Buscar archivos en grabadora/tarjeta...</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlg._linkFindFiles</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.DriveLetterHintMsgLabel">
         <source xml:lang="en">In Windows, if you assign the device to a letter closer to 'z', it is more likely to use that letter each time.</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.DriveLetterHintMsgLabel</note>
         <target xml:lang="es-ES" state="translated">En Windows, si asigna el dispositivo a una letra más cercana a 'z', es más probable que se utilice esa letra cada vez.</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.DriveLetterHintMsgLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel1">
         <source xml:lang="en">1) The device is not yet plugged in.</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel1</note>
         <target xml:lang="es-ES" state="translated">1) El dispositivo todavía no está conectado.</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel1</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel2">
         <source xml:lang="en">2) The device is plugged in but is currently assigned a different drive letter from '{0}'.</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel2</note>
         <target xml:lang="es-ES" state="translated">2) El dispositivo está conectado pero actualmente está asignado a otra letra de unidad en vez de '{0}'.</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel2</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel3">
         <source xml:lang="en">3) Some part of the above path has changed (e.g. a folder name).</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel3</note>
         <target xml:lang="es-ES" state="translated">3) Parte de la ruta carpeta anterior ha cambiado (por ejemplo, el nombre de una carpeta).</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.PossibleProblemsMsgLabel3</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.ProblemOverviewMsgLabel">
         <source xml:lang="en">SayMore cannot reach the folder where your files were last time. One of the following may be true:</source>
-        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.ProblemOverviewMsgLabel</note>
         <target xml:lang="es-ES" state="translated">SayMore no puede llegar a la carpeta donde los archivos se encontraban anteriormente. Uno de los siguientes puede ser la causa:</target>
+        <note>ID: DialogBoxes.NewSessionsFromFilesDlgFolderNotFoundMesssageBox.ProblemOverviewMsgLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ProgressDlg.CancellingMsg">
         <source xml:lang="en">Canceling...</source>
-        <note>ID: DialogBoxes.ProgressDlg.CancellingMsg</note>
         <target xml:lang="es-ES" state="translated">Cancelando...</target>
+        <note>ID: DialogBoxes.ProgressDlg.CancellingMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ProgressDlg._buttonCancel">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.ProgressDlg._buttonCancel</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.ProgressDlg._buttonCancel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.ProgressDlg._buttonOK">
         <source xml:lang="en">OK</source>
-        <note>ID: DialogBoxes.ProgressDlg._buttonOK</note>
         <target xml:lang="es-ES" state="translated">Aceptar</target>
+        <note>ID: DialogBoxes.ProgressDlg._buttonOK</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.CancelButtonText">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.CancelButtonText</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.CancelButtonText</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.ErrorMovingRecordingToSessionFolder">
         <source xml:lang="en">There was an error moving your recording to the session folder for '{0}'.\n\nUnexpectedly, SayMore has probably kept a lock on the file; therefore, the recording will not be deleted and it may be copied from your temporary folder after closing SayMore.\n\nThe file is:\n\n{1}.</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.ErrorMovingRecordingToSessionFolder</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al migrar la grabación a la carpeta de sesión para '{0}'.\n\nInesperadamente, SayMore probablemente ha mantenido un bloqueo en el archivo. Por lo tanto, no se borrará la grabación. Después de cerrar SayMore, usted lo puede copiar desde la carpeta temporal .\n\nNombre del archivo:\n\n{1}</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.ErrorMovingRecordingToSessionFolder</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.OKButtonText">
         <source xml:lang="en">OK</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.OKButtonText</note>
         <target xml:lang="es-ES" state="translated">Aceptar</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.OKButtonText</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.PlaybackButtonText">
         <source xml:lang="en">Play Back Recording</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.PlaybackButtonText</note>
         <target xml:lang="es-ES" state="translated">Reproducir grabación</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.PlaybackButtonText</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.RecordButtonText">
         <source xml:lang="en">Record</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.RecordButtonText</note>
         <target xml:lang="es-ES" state="translated">Grabar</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.RecordButtonText</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.RecordedLengthLabel">
         <source xml:lang="en">Recorded Length: {0} sec.</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.RecordedLengthLabel</note>
         <target xml:lang="es-ES" state="translated">Duración: {0} seg.</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.RecordedLengthLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.RecordingFormatLabel">
         <source xml:lang="en">Format: {0} bits, {1} Hz</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.RecordingFormatLabel</note>
         <target xml:lang="es-ES" state="translated">Formato: {0} bits, {1} Hz</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.RecordingFormatLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.RetryAfterUnauthorizedAccessExceptionMsg">
         <source xml:lang="en">If you can determine which program is using this file, close it and click Retry.</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.RetryAfterUnauthorizedAccessExceptionMsg</note>
         <target xml:lang="es-ES" state="translated">Si usted puede determinar cuál programa está utilizando este archivo, ciérrelo y haga clic en Reintentar.</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.RetryAfterUnauthorizedAccessExceptionMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.StopButtonText">
         <source xml:lang="en">Stop</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.StopButtonText</note>
         <target xml:lang="es-ES" state="translated">Parar</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.StopButtonText</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.UnableToStartRecording">
         <source xml:lang="en">Unable to start recording.</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.UnableToStartRecording</note>
         <target xml:lang="es-ES" state="translated">No se pudo empezar a grabar.</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.UnableToStartRecording</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SessionRecorderDlg.WindowTitle">
         <source xml:lang="en">Session Recorder</source>
-        <note>ID: DialogBoxes.SessionRecorderDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Grabadora de sesión</target>
+        <note>ID: DialogBoxes.SessionRecorderDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SplashScreen.LoadingLabel">
         <source xml:lang="en">Loading...</source>
-        <note>ID: DialogBoxes.SplashScreen.LoadingLabel</note>
         <target xml:lang="es-ES" state="translated">Cargando...</target>
+        <note>ID: DialogBoxes.SplashScreen.LoadingLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.SplashScreen.VersionInfoLabel">
         <source xml:lang="en">Version {0}.{1}.{2} {3}    Built on {4}</source>
-        <note>ID: DialogBoxes.SplashScreen.VersionInfoLabel</note>
         <target xml:lang="es-ES" state="translated">Versión {0}.{1}.{2} {3} compilado {4}</target>
+        <note>ID: DialogBoxes.SplashScreen.VersionInfoLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CarefulSpeechRecorderDlg.WindowTitle">
         <source xml:lang="en">Careful Speech Recorder</source>
-        <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Grabación de habla cuidadosa</target>
+        <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CarefulSpeechRecorderDlg._labelCarefulSpeech">
         <source xml:lang="en">Careful Speech</source>
-        <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg._labelCarefulSpeech</note>
         <target xml:lang="es-ES" state="translated">Habla cuidadosa</target>
+        <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg._labelCarefulSpeech</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.WindowTitle">
         <source xml:lang="en">Change this text</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.WindowTitle</note>
-        <note>Do not translate - Localized in subclass</note>
         <target xml:lang="es-ES" state="needs-translation">Change this text</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._buttonCancel">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._buttonCancel</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._buttonCancel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._buttonClose">
         <source xml:lang="en">OK</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._buttonClose</note>
         <target xml:lang="es-ES" state="translated">Aceptar</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._buttonClose</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._comboBoxZoom_ToolTip_">
         <source xml:lang="en">Ctrl+1: In; Ctrl+2: 100%; Ctrl+3: Out</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._comboBoxZoom_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Ctrl + 1: Ampliar; Ctrl + 2:100 %; Ctrl + 3: Reducir</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._comboBoxZoom_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._ignoreToolStripMenuItem">
         <source xml:lang="en">Ignored</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._ignoreToolStripMenuItem</note>
         <target xml:lang="es-ES" state="translated">Ignorado</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._ignoreToolStripMenuItem</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._ignoreToolStripMenuItem_ToolTip_">
         <source xml:lang="en">Mark this segment as Ignored to skip annotating it.</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._ignoreToolStripMenuItem_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Seleccionar Ignorado para no anotar este segmento.</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._ignoreToolStripMenuItem_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelOriginalRecording">
         <source xml:lang="en">Source Audio</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelOriginalRecording</note>
         <target xml:lang="es-ES" state="translated">Audio original</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelOriginalRecording</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelSegmentNumber">
         <source xml:lang="en">Segments: {0}</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelSegmentNumber</note>
         <target xml:lang="es-ES" state="translated">Segmentos: {0}</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelSegmentNumber</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelSegmentXofY">
         <source xml:lang="en">Segment {0} of {1}</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelSegmentXofY</note>
         <target xml:lang="es-ES" state="translated">Segmento {0} de {1}</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelSegmentXofY</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelZoom">
         <source xml:lang="en">&amp;Zoom:</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelZoom</note>
         <target xml:lang="es-ES" state="translated">&amp;Zoom:</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._labelZoom</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._undoToolStripMenuItem">
         <source xml:lang="en">Undo</source>
-        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._undoToolStripMenuItem</note>
         <target xml:lang="es-ES" state="translated">Deshacer</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg._undoToolStripMenuItem</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CreateAnnotationFileDlg.AllFileTypeString">
         <source xml:lang="en">All Files (*.*)|*.*</source>
-        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.AllFileTypeString</note>
         <target xml:lang="es-ES" state="translated">Todos los archivos (*.*)|*.*</target>
+        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.AllFileTypeString</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CreateAnnotationFileDlg.AudacityLabelOpenFileDlg.Caption">
         <source xml:lang="en">Select Audacity Label File</source>
-        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.AudacityLabelOpenFileDlg.Caption</note>
         <target xml:lang="es-ES" state="translated">Seleccione archivo de etiquetas de Audacity</target>
+        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.AudacityLabelOpenFileDlg.Caption</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CreateAnnotationFileDlg.AudacityLabelOpenFileDlg.FileTypeString">
         <source xml:lang="en">Audacity Label File (*.txt)|*.txt</source>
-        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.AudacityLabelOpenFileDlg.FileTypeString</note>
         <target xml:lang="es-ES" state="translated">Archivo de etiquetas de Audacity (*.txt)|*.txt</target>
+        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.AudacityLabelOpenFileDlg.FileTypeString</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CreateAnnotationFileDlg.ElanFileTypeString">
         <source xml:lang="en">ELAN File (*.eaf)|*.eaf</source>
-        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.ElanFileTypeString</note>
         <target xml:lang="es-ES" state="translated">Archivo ELAN (*.eaf)|*.eaf</target>
+        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.ElanFileTypeString</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CreateAnnotationFileDlg.LoadSegmentFileDlgCaption">
         <source xml:lang="en">Select Segment File</source>
-        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.LoadSegmentFileDlgCaption</note>
         <target xml:lang="es-ES" state="translated">Seleccione archivo de segmentos</target>
+        <note>ID: DialogBoxes.Transcription.CreateAnnotationFileDlg.LoadSegmentFileDlgCaption</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1">
         <source xml:lang="en">In order to export, we need to find a writing system ID that FLEx will accept. SayMore tried to find a list of writing systems which FLEx knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1</note>
-        <note>The parameter is a folder path</note>
         <target xml:lang="es-ES" state="translated">Para exportar se requiere un sistema de escritura que FLEx reconoce. SayMore intentó encontrar la lista de sistemas de escritura que FLEx reconoce buscándola en {0}, pero no existe. Recomendamos que use el código 'en' (inglés). A continuación usted lo puede cambiar dentro de FLEx.</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2">
         <source xml:lang="en">SayMore was unable to find any Writing Systems on this computer. Make sure FLEx version 7.1 or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into FLEx.</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2</note>
         <target xml:lang="es-ES" state="translated">SayMore no pudo encontrar ningún sistema de escritura en este equipo. Hacer seguro FLEx versión 7.1 o superior instalado como se ha ejecutado al menos una vez. Por ahora, puede exportar como inglés y arreglar eso después de que haya importado en FLEx.</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton">
         <source xml:lang="en">Export...</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton</note>
         <target xml:lang="es-ES" state="translated">Exportar...</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption">
         <source xml:lang="en">Export to File</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption</note>
         <target xml:lang="es-ES" state="translated">Exportar a archivo</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString">
         <source xml:lang="en">FLEx Interlinear (*.flextext)|*.flextext|All Files (*.*)|*.*</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString</note>
         <target xml:lang="es-ES" state="translated">FLEx Interlineal (*.flextext)|*.flextext|Todos los archivos (*.*)|*.*</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg">
         <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg</note>
-        <note>The parameter is an error message</note>
         <target xml:lang="es-ES" state="translated">Hubo un problema al inicializar el repositorio de los sistemas de escritura: "{0}". Se recomienda que deje que el código sea 'en' (inglés), luego cambiarlo dentro de FLEx.</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel">
         <source xml:lang="en">{0}:</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel</note>
         <target xml:lang="es-ES" state="translated">{0}:</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.OverviewLabel">
         <source xml:lang="en">Specify the writing systems for the transcriptions and free translations.</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.OverviewLabel</note>
         <target xml:lang="es-ES" state="translated">Especificar los sistemas de escritura para las transcripciones y traducciones libres.</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.OverviewLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.TranscriptionLabel">
         <source xml:lang="en">{0}:</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.TranscriptionLabel</note>
         <target xml:lang="es-ES" state="translated">{0}:</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.TranscriptionLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.WindowTitle">
         <source xml:lang="en">Export Annotations For FieldWorks Interlinear</source>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Exportación de anotaciones a FieldWorks interlineal</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.ButtonTextWhenSegmentTooShort">
         <source xml:lang="en">Whoops! The segment will be too short. Continue listening.</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.ButtonTextWhenSegmentTooShort</note>
         <target xml:lang="es-ES" state="translated">El segmento será demasiado corto. Siga escuchando.</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.ButtonTextWhenSegmentTooShort</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.CarefulSpeechAnnotation">
         <source xml:lang="en">Careful Speech</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.CarefulSpeechAnnotation</note>
-        <note>Type of oral annotation listed in message box to confirm deletion</note>
         <target xml:lang="es-ES" state="translated">Habla cuidadosa</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.CarefulSpeechAnnotation</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.ConfirmDeletionOfOralAnnotationsForAddedBreak">
         <source xml:lang="en">Adding a segment break here would split a segment which has existing oral annotations of the following types:{0}Would you like to proceed with the addition of this segment break and delete the oral annotations?</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.ConfirmDeletionOfOralAnnotationsForAddedBreak</note>
         <target xml:lang="es-ES" state="translated">Añadir una división de segmento aquí dividiría un segmento que tiene anotaciones orales existentes de los siguientes tipos:{0}¿Desea continuar con la adición de esta división y borrarr las anotaciones orales?</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.ConfirmDeletionOfOralAnnotationsForAddedBreak</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.ConfirmDeletionOfOralAnnotationsForDeletedBreak">
         <source xml:lang="en">Would you like to proceed with the deletion of this segment break and delete the oral annotations?</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.ConfirmDeletionOfOralAnnotationsForDeletedBreak</note>
         <target xml:lang="es-ES" state="translated">¿Desea borrar esta división y las anotaciones orales?</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.ConfirmDeletionOfOralAnnotationsForDeletedBreak</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.DeletionOfBreakWillDeleteOralAnnotations">
         <source xml:lang="en">Deleting this segment break would delete a segment which has existing oral annotations:</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.DeletionOfBreakWillDeleteOralAnnotations</note>
         <target xml:lang="es-ES" state="translated">Borrar la división seleccionado borraría un segmento que tiene anotaciones orales existentes:</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.DeletionOfBreakWillDeleteOralAnnotations</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.FollowingSegment">
         <source xml:lang="en">Following Segment ({0})</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.FollowingSegment</note>
         <target xml:lang="es-ES" state="translated">Segmento posterior ({0})</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.FollowingSegment</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.GeneralSegmentingErrorMsg">
         <source xml:lang="en">There was an error segmenting the file '{0}'.</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.GeneralSegmentingErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error en la segmentación del archivo '{0}'.</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.GeneralSegmentingErrorMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.JoinSegmentsWithOralAnnotations">
         <source xml:lang="en">Deleting this segment break would join segments which have existing oral annotations:</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.JoinSegmentsWithOralAnnotations</note>
         <target xml:lang="es-ES" state="translated">Borrar la división seleccionado uniría segmentos que tienen anotaciones orales existentes:</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.JoinSegmentsWithOralAnnotations</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.OralTranslationAnnotation">
         <source xml:lang="en">Oral Translation</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.OralTranslationAnnotation</note>
-        <note>Type of oral annotation listed in message box to confirm deletion</note>
         <target xml:lang="es-ES" state="translated">Traducción oral</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.OralTranslationAnnotation</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.PrecedingSegment">
         <source xml:lang="en">Preceding Segment ({0})</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.PrecedingSegment</note>
         <target xml:lang="es-ES" state="translated">Segmento anterior ({0})</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.PrecedingSegment</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.SavingSegmentsErrorMsg">
         <source xml:lang="en">There was an error while trying to save segments for the file '{0}'.</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.SavingSegmentsErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al intentar grabar los segmentos para el archivo '{0}'.</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.SavingSegmentsErrorMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg.WindowTitle">
         <source xml:lang="en">Manual Segmenter</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Segmentador manual</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg._buttonAddSegmentBoundary.Normal">
         <source xml:lang="en">Add Segment Boundary (press ENTER)</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._buttonAddSegmentBoundary.Normal</note>
         <target xml:lang="es-ES" state="translated">Añadir division de segmento (presione ENTER)</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._buttonAddSegmentBoundary.Normal</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg._buttonDeleteBoundary">
         <source xml:lang="en">Delete Selected Boundary (press DELETE)</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._buttonDeleteBoundary</note>
         <target xml:lang="es-ES" state="translated">Borrar la división seleccionado (presione Supr)</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._buttonDeleteBoundary</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg._buttonListenToOriginal">
         <source xml:lang="en">Listen (press the SPACE BAR)</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._buttonListenToOriginal</note>
         <target xml:lang="es-ES" state="translated">Escuchar (presione la barra espaciadora)</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._buttonListenToOriginal</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg._buttonStopOriginal">
         <source xml:lang="en">Stop (press the SPACE BAR)</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._buttonStopOriginal</note>
         <target xml:lang="es-ES" state="translated">Parar (presione la barra espaciadora)</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._buttonStopOriginal</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ManualSegmenterDlg._labelInfo">
         <source xml:lang="en">One of the segments delineated by the selected break already has oral annotations.</source>
-        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._labelInfo</note>
         <target xml:lang="es-ES" state="translated">Uno de los segmentos delineados por la división de segmentos seleccionada ya tiene anotaciones orales.</target>
+        <note>ID: DialogBoxes.Transcription.ManualSegmenterDlg._labelInfo</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.CannotRecordErrorMsg">
         <source xml:lang="en">Recording not working. Please make sure your microphone is plugged in.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.CannotRecordErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Grabación no funciona. Asegúrese de que el micrófono esté conectado.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.CannotRecordErrorMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.ListenButton">
         <source xml:lang="en">Listen</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.ListenButton</note>
         <target xml:lang="es-ES" state="translated">Escuchar</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.ListenButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.ListenButton_ToolTip_">
         <source xml:lang="en">Hold button down to listen\nto original recording</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.ListenButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Mantenga el botón presionado para\nreproducir la grabación original</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.ListenButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.MessageWhenSegmentTooShortHoldingSpace">
         <source xml:lang="en">You need to keep the SPACE BAR down while you listen.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.MessageWhenSegmentTooShortHoldingSpace</note>
         <target xml:lang="es-ES" state="translated">Mantenga presionado la barra espaciadora mientras escucha la reproducción.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.MessageWhenSegmentTooShortHoldingSpace</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.MessageWhenSegmentTooShortPressingButton">
         <source xml:lang="en">You need to hold the button down while you listen.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.MessageWhenSegmentTooShortPressingButton</note>
         <target xml:lang="es-ES" state="translated">Mantenga presionado el botón mientras escucha la reproducción.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.MessageWhenSegmentTooShortPressingButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.NoAnnotationToolTipMsg">
         <source xml:lang="en">This segment does not have a recorded annotation.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.NoAnnotationToolTipMsg</note>
         <target xml:lang="es-ES" state="translated">Este segmento no tiene una anotación grabado.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.NoAnnotationToolTipMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.PlayAnnotationToolTipMsg">
         <source xml:lang="en">Listen to this annotation.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.PlayAnnotationToolTipMsg</note>
         <target xml:lang="es-ES" state="translated">Escuchar esta anotación.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.PlayAnnotationToolTipMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.PlayOriginalShortcutToolTipHint">
         <source xml:lang="en">Keyboard shortcut: 'b'</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.PlayOriginalShortcutToolTipHint</note>
         <target xml:lang="es-ES" state="translated">Método abreviado de teclado: 'b'</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.PlayOriginalShortcutToolTipHint</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordButton">
         <source xml:lang="en">Speak</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordButton</note>
         <target xml:lang="es-ES" state="translated">Hablar</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordButton_ToolTip_">
         <source xml:lang="en">Hold button down to record</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Mantenga pulsado el botón para grabar</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAbortedCaption">
         <source xml:lang="en">Recording Failed</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAbortedCaption</note>
         <target xml:lang="es-ES" state="translated">Error de grabación</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAbortedCaption</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAbortedMessage">
         <source xml:lang="en">The recording was interrupted by a change in the default recording device.\nThis can happen if you turn off or disconnect the microphone.\nAfter you correct the problem, click OK, and then record again.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAbortedMessage</note>
         <target xml:lang="es-ES" state="translated">La grabación fue interrumpido por un cambio en el dispositivo de grabación predeterminado.\nEsto puede ocurrir si se apaga o se desconecta el micrófono.\nDespués de corregir el problema, haga clic en Aceptar y, a continuación, volver a grabar.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAbortedMessage</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAnnotationMsg">
         <source xml:lang="en">Recording...\nLength: {0}</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAnnotationMsg</note>
         <target xml:lang="es-ES" state="translated">Grabando...\nDuración: {0}</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingAnnotationMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingTooShortMessage.WhenOnlyMouseIsValid">
         <source xml:lang="en">Whoops. You need to hold down the mouse button while talking.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingTooShortMessage.WhenOnlyMouseIsValid</note>
         <target xml:lang="es-ES" state="translated">Mantenga presionado el botón del ratón mientras habla.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingTooShortMessage.WhenOnlyMouseIsValid</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingTooShortMessage.WhenSpaceOrMouseIsValid">
         <source xml:lang="en">Whoops. You need to hold down the SPACE BAR or mouse button while talking.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingTooShortMessage.WhenSpaceOrMouseIsValid</note>
         <target xml:lang="es-ES" state="translated">Mantenga presionado la barra espaciadora o el botón del ratón mientras habla.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RecordingTooShortMessage.WhenSpaceOrMouseIsValid</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RerecordAnnotationToolTipMsg">
         <source xml:lang="en">To erase the recorded annotation for this segment and record a new one, press and hold this button.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RerecordAnnotationToolTipMsg</note>
         <target xml:lang="es-ES" state="translated">Para borrar la annotación grabada para este segmento y grabar de nuevo, presione y mantenga presionado este botón.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.RerecordAnnotationToolTipMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.SkippedSegmentToolTipMsg">
         <source xml:lang="en">This segment was skipped.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.SkippedSegmentToolTipMsg</note>
         <target xml:lang="es-ES" state="translated">Este segmento se ha omitido.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.SkippedSegmentToolTipMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.UndoToolTipMsg">
         <source xml:lang="en">Undo: {0} (Ctrl-Z or Z)</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.UndoToolTipMsg</note>
         <target xml:lang="es-ES" state="translated">Deshacer: {0} (Ctrl-Z)</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.UndoToolTipMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.UnexpectedErrorAttemptingToRecordMsg">
         <source xml:lang="en">An unexpected error occurred when attempting to record an annotation.</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.UnexpectedErrorAttemptingToRecordMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error inesperado al intentar grabar una anotación.</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.UnexpectedErrorAttemptingToRecordMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.WindowTitle">
         <source xml:lang="en">Change this text</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.WindowTitle</note>
-        <note>Do not translate - Localized in subclass</note>
         <target xml:lang="es-ES" state="needs-translation">Change this text</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelFinishedHint">
         <source xml:lang="en">Finished</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelFinishedHint</note>
         <target xml:lang="es-ES" state="translated">Finalizado</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelFinishedHint</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelListenHint">
         <source xml:lang="en">To listen to the source recording, press and hold the SPACE BAR</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelListenHint</note>
         <target xml:lang="es-ES" state="translated">Para reproducir la grabación original mantenga presionado la barra espaciadora</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelListenHint</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelRecordHint">
         <source xml:lang="en">To record, press and hold the SPACE BAR</source>
-        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelRecordHint</note>
         <target xml:lang="es-ES" state="translated">Para grabar, mantenga presionado la barra espaciadora</target>
+        <note>ID: DialogBoxes.Transcription.OralAnnotationRecorderDlgBase._labelRecordHint</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralTranslationRecorderDlg.WindowTitle">
         <source xml:lang="en">Oral Translation Recorder</source>
-        <note>ID: DialogBoxes.Transcription.OralTranslationRecorderDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Grabación de traducciónes orales</target>
+        <note>ID: DialogBoxes.Transcription.OralTranslationRecorderDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.OralTranslationRecorderDlg._labelOralTranslation">
         <source xml:lang="en">Oral Translation</source>
-        <note>ID: DialogBoxes.Transcription.OralTranslationRecorderDlg._labelOralTranslation</note>
         <target xml:lang="es-ES" state="translated">Traducción oral</target>
+        <note>ID: DialogBoxes.Transcription.OralTranslationRecorderDlg._labelOralTranslation</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.MessageWhenSegmentTooShortManualDragging">
         <source xml:lang="en">Whoops! The segment will be too short.</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.MessageWhenSegmentTooShortManualDragging</note>
         <target xml:lang="es-ES" state="translated">El segmento será demasiado corto.</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.MessageWhenSegmentTooShortManualDragging</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.PlayOriginalToolTipMsg">
         <source xml:lang="en">Listen to this segment.</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.PlayOriginalToolTipMsg</note>
         <target xml:lang="es-ES" state="translated">Escuchar este segmento</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.PlayOriginalToolTipMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.SaveChangesQuestion">
         <source xml:lang="en">Would you like to save your changes?</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.SaveChangesQuestion</note>
         <target xml:lang="es-ES" state="translated">¿Desea guardar los cambios?</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.SaveChangesQuestion</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.Segmenting3ChannelAudioFilesNotSupportedMsg">
         <source xml:lang="en">Segmenting {0} channel audio files is not supported.</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.Segmenting3ChannelAudioFilesNotSupportedMsg</note>
         <target xml:lang="es-ES" state="translated">No se puede realizar segmentación de archivos con audio de {0} canales.</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.Segmenting3ChannelAudioFilesNotSupportedMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.SegmentingAudioFormatNotSupportedMsg">
         <source xml:lang="en">Segmenting {0} bit, {1} audio files is not supported.</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.SegmentingAudioFormatNotSupportedMsg</note>
         <target xml:lang="es-ES" state="translated">No se puede realizar segmentación de archivos de {0} bits, {1} audio.</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.SegmentingAudioFormatNotSupportedMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.AnnotationDeleted">
         <source xml:lang="en">Deletion of annotation for segment {0}</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.AnnotationDeleted</note>
-        <note>Parameter is time range of the segment for which the annotation was deleted (This undo action is included for completeness, but currently never gets displayed in UI).</note>
         <target xml:lang="es-ES" state="needs-translation">Deletion of annotation for segment {0}</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.AnnotationDeleted</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.AnnotationRecording">
         <source xml:lang="en">Recording annotation for segment {0}</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.AnnotationRecording</note>
-        <note>Parameter is time range of the segment for which the annotation was recorded.</note>
         <target xml:lang="es-ES" state="translated">Grabación de anotación para el segmento {0}</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.AnnotationRecording</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentAddition">
         <source xml:lang="en">Addition of segment {0}</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentAddition</note>
-        <note>Parameter is time range of added segment.</note>
         <target xml:lang="es-ES" state="translated">Adición del segmento {0}</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentAddition</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentBoundaryMove">
         <source xml:lang="en">Segment boundary change from {0} to {1}</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentBoundaryMove</note>
-        <note>Parameter 0 is the original time range of the segment. Parameter 1 is the new time range.</note>
         <target xml:lang="es-ES" state="translated">Cambio de límite de segmento desde {0} a {1}</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentBoundaryMove</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentDeletion">
         <source xml:lang="en">Deletion of segment {0}</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentDeletion</note>
-        <note>Parameter is time range of deleted segment.</note>
         <target xml:lang="es-ES" state="translated">Eliminación del segmento {0}</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentDeletion</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentIgnored">
         <source xml:lang="en">Ignoring segment {0}</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentIgnored</note>
-        <note>Parameter is time range of the segment that was ignored.</note>
         <target xml:lang="es-ES" state="translated">Ignorar el segmento {0}</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentIgnored</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentUnignored">
         <source xml:lang="en">Marking segment {0} as relevant</source>
-        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentUnignored</note>
-        <note>Parameter is time range of the segment that was ignored.</note>
         <target xml:lang="es-ES" state="translated">Marcar segmento {0} como relevante</target>
+        <note>ID: DialogBoxes.Transcription.SegmenterDlgBase.UndoAction.SegmentUnignored</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.UserInterfaceLanguageDlg.CancelButton">
         <source xml:lang="en">Cancel</source>
-        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.CancelButton</note>
         <target xml:lang="es-ES" state="translated">Cancelar</target>
+        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.CancelButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.UserInterfaceLanguageDlg.HelpOnLocalizingLink">
         <source xml:lang="en">Help on localization</source>
-        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.HelpOnLocalizingLink</note>
         <target xml:lang="es-ES" state="translated">Ayuda sobre localización</target>
+        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.HelpOnLocalizingLink</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.UserInterfaceLanguageDlg.IWantToLocalizeLink">
         <source xml:lang="en">I want to localize SayMore for another language...</source>
-        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.IWantToLocalizeLink</note>
         <target xml:lang="es-ES" state="translated">Localizar SayMore...</target>
+        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.IWantToLocalizeLink</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.UserInterfaceLanguageDlg.LanguageLabel">
         <source xml:lang="en">&amp;Language:</source>
-        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.LanguageLabel</note>
         <target xml:lang="es-ES" state="translated">&amp;Idioma:</target>
+        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.LanguageLabel</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.UserInterfaceLanguageDlg.OKButton">
         <source xml:lang="en">OK</source>
-        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.OKButton</note>
         <target xml:lang="es-ES" state="translated">Aceptar</target>
+        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.OKButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.UserInterfaceLanguageDlg.ViewLocalizationsLink">
         <source xml:lang="en">View SayMore localizations...</source>
-        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.ViewLocalizationsLink</note>
         <target xml:lang="es-ES" state="translated">Ver localizaciones de SayMore...</target>
+        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.ViewLocalizationsLink</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.UserInterfaceLanguageDlg.WindowTitle">
         <source xml:lang="en">User Interface Language</source>
-        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">Idomas de interfaz de usuario</target>
+        <note>ID: DialogBoxes.UserInterfaceLanguageDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg.OpenFileDlgCaption">
         <source xml:lang="en">Open SayMore Project</source>
-        <note>ID: DialogBoxes.WelcomeDlg.OpenFileDlgCaption</note>
         <target xml:lang="es-ES" state="translated">Abrir proyecto de SayMore</target>
+        <note>ID: DialogBoxes.WelcomeDlg.OpenFileDlgCaption</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg.ProjectFileType">
         <source xml:lang="en">SayMore Project</source>
-        <note>ID: DialogBoxes.WelcomeDlg.ProjectFileType</note>
         <target xml:lang="es-ES" state="translated">Proyecto SayMore</target>
+        <note>ID: DialogBoxes.WelcomeDlg.ProjectFileType</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg.WindowTitle">
         <source xml:lang="en">SayMore</source>
-        <note>ID: DialogBoxes.WelcomeDlg.WindowTitle</note>
         <target xml:lang="es-ES" state="translated">SayMore</target>
+        <note>ID: DialogBoxes.WelcomeDlg.WindowTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._buttonBrowse">
         <source xml:lang="en">Browse for project...</source>
-        <note>ID: DialogBoxes.WelcomeDlg._buttonBrowse</note>
         <target xml:lang="es-ES" state="translated">Buscar proyecto...</target>
+        <note>ID: DialogBoxes.WelcomeDlg._buttonBrowse</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._buttonBrowse_ToolTip_">
         <source xml:lang="en">Browse the file system for a project</source>
-        <note>ID: DialogBoxes.WelcomeDlg._buttonBrowse_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Examinar el sistema de archivos para un proyecto</target>
+        <note>ID: DialogBoxes.WelcomeDlg._buttonBrowse_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._buttonCreate">
         <source xml:lang="en">Create new, blank project...</source>
-        <note>ID: DialogBoxes.WelcomeDlg._buttonCreate</note>
         <target xml:lang="es-ES" state="translated">Crear nuevo proyecto en blanco...</target>
+        <note>ID: DialogBoxes.WelcomeDlg._buttonCreate</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._buttonCreate_ToolTip_">
         <source xml:lang="en">Create a blank project</source>
-        <note>ID: DialogBoxes.WelcomeDlg._buttonCreate_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Crear un proyecto en blanco</target>
+        <note>ID: DialogBoxes.WelcomeDlg._buttonCreate_ToolTip_</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._labelCreate">
         <source xml:lang="en">Create</source>
-        <note>ID: DialogBoxes.WelcomeDlg._labelCreate</note>
         <target xml:lang="es-ES" state="translated">Crear</target>
+        <note>ID: DialogBoxes.WelcomeDlg._labelCreate</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._labelOpen">
         <source xml:lang="en">Open</source>
-        <note>ID: DialogBoxes.WelcomeDlg._labelOpen</note>
         <target xml:lang="es-ES" state="translated">Abrir</target>
+        <note>ID: DialogBoxes.WelcomeDlg._labelOpen</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._labelSubTitle">
         <source xml:lang="en">Language Documentation Project Management</source>
-        <note>ID: DialogBoxes.WelcomeDlg._labelSubTitle</note>
         <target xml:lang="es-ES" state="translated">Gestión de proyectos de documentación de idiomas</target>
+        <note>ID: DialogBoxes.WelcomeDlg._labelSubTitle</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._labelVersionInfo">
         <source xml:lang="en">Version {0}.{1}.{2} {3}    Built on {4}</source>
-        <note>ID: DialogBoxes.WelcomeDlg._labelVersionInfo</note>
         <target xml:lang="es-ES" state="translated">Versión {0}.{1}.{2} {3} Compilado: {4}</target>
+        <note>ID: DialogBoxes.WelcomeDlg._labelVersionInfo</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._linkSILWebsite">
         <source xml:lang="en">This free software is published by {0}.</source>
-        <note>ID: DialogBoxes.WelcomeDlg._linkSILWebsite</note>
-        <note>Parameter is the publisher of SayMore, "SIL International"</note>
         <target xml:lang="es-ES" state="translated">Publicado por {0}.</target>
+        <note>ID: DialogBoxes.WelcomeDlg._linkSILWebsite</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.WelcomeDlg._linkSayMoreWebsite">
         <source xml:lang="en">Visit {0} on the Web.</source>
-        <note>ID: DialogBoxes.WelcomeDlg._linkSayMoreWebsite</note>
-        <note>Parameter is the program name, "SayMore"</note>
         <target xml:lang="es-ES" state="translated">Visite {0} en la Web.</target>
+        <note>ID: DialogBoxes.WelcomeDlg._linkSayMoreWebsite</note>
       </trans-unit>
       <trans-unit id="MainWindow.AutoCompleteValueGathererError">
         <source xml:lang="en">An error of type {0} ocurred trying to gather information from file: {1}</source>
-        <note>ID: MainWindow.AutoCompleteValueGathererError</note>
-        <note>Parameter 0 is an exception type; parameter 1 is a file name</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error de tipo {0} intentando reunir información del archivo: {1}</target>
+        <note>ID: MainWindow.AutoCompleteValueGathererError</note>
       </trans-unit>
       <trans-unit id="MainWindow.ConfirmDeleteUserSettingsFile">
         <source xml:lang="en">Do you want to delete your user settings? (This will clear your most-recently-used project list, window positions, UI language settings, etc. It will not affect your SayMore project data.)</source>
-        <note>ID: MainWindow.ConfirmDeleteUserSettingsFile</note>
         <target xml:lang="es-ES" state="translated">¿Desea borrar la configuración de usuario? (Esto borrará la lista de los proyectos más recientemente usados, ubicación de ventanas, configuración del idioma de interfaz de usuario, etc. No afectará los datos de los proyectos SayMore.)</target>
+        <note>ID: MainWindow.ConfirmDeleteUserSettingsFile</note>
       </trans-unit>
       <trans-unit id="MainWindow.ConfirmStopFileSync">
         <source xml:lang="en">It looks like this project is in a directory that is being synchronized with {0}. This is known to cause problems due to files being locked. Would you like to disable {0} temporarily until you close SayMore?</source>
-        <note>ID: MainWindow.ConfirmStopFileSync</note>
-        <note>Param: Known folder synchronization program (Dropbox, Google Drive, etc.)</note>
         <target xml:lang="es-ES" state="translated">Parece que este proyecto está en una carpeta que está sincronizado con {0}. Se sabe que esto puede causar problemas debido a que los archivos están siendo bloqueados. ¿Desea desactivar {0} temporalmente hasta que cierre SayMore?</target>
+        <note>ID: MainWindow.ConfirmStopFileSync</note>
       </trans-unit>
       <trans-unit id="MainWindow.DeleteOneItemMsg">
         <source xml:lang="en">{0}</source>
-        <note>ID: MainWindow.DeleteOneItemMsg</note>
-        <note>For deleting sessions and people items</note>
         <target xml:lang="es-ES" state="translated">{0}</target>
+        <note>ID: MainWindow.DeleteOneItemMsg</note>
       </trans-unit>
       <trans-unit id="MainWindow.DeletePersonMenuText">
         <source xml:lang="en">&amp;Delete Person...</source>
-        <note>ID: MainWindow.DeletePersonMenuText</note>
         <target xml:lang="es-ES" state="translated">&amp;Borrar persona...</target>
+        <note>ID: MainWindow.DeletePersonMenuText</note>
       </trans-unit>
       <trans-unit id="MainWindow.DeleteSessionMenuText">
         <source xml:lang="en">&amp;Delete Session...</source>
-        <note>ID: MainWindow.DeleteSessionMenuText</note>
         <target xml:lang="es-ES" state="translated">&amp;Borrar sesión...</target>
+        <note>ID: MainWindow.DeleteSessionMenuText</note>
       </trans-unit>
       <trans-unit id="MainWindow.ElementNoLongerExistsMsg">
         <source xml:lang="en">'{0}' doesn't exist in elements collection.</source>
-        <note>ID: MainWindow.ElementNoLongerExistsMsg</note>
         <target xml:lang="es-ES" state="translated">'{0}' no existe en la colección de entidades.</target>
+        <note>ID: MainWindow.ElementNoLongerExistsMsg</note>
       </trans-unit>
       <trans-unit id="MainWindow.Export.ExportFailureMsg">
         <source xml:lang="en">Something went wrong with the export.</source>
-        <note>ID: MainWindow.Export.ExportFailureMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error en la exportación.</target>
+        <note>ID: MainWindow.Export.ExportFailureMsg</note>
       </trans-unit>
       <trans-unit id="MainWindow.Export.ExportFileSaveFileDlg.CSVFileTypeText">
         <source xml:lang="en">CSV (Comma delimited) (*.csv)|*.csv</source>
-        <note>ID: MainWindow.Export.ExportFileSaveFileDlg.CSVFileTypeText</note>
         <target xml:lang="es-ES" state="translated">CSV (delimitado por comas) (*.csv)|*.csv</target>
+        <note>ID: MainWindow.Export.ExportFileSaveFileDlg.CSVFileTypeText</note>
       </trans-unit>
       <trans-unit id="MainWindow.Export.ExportFileSaveFileDlg.Caption">
         <source xml:lang="en">Export Data</source>
-        <note>ID: MainWindow.Export.ExportFileSaveFileDlg.Caption</note>
         <target xml:lang="es-ES" state="translated">Exportar datos</target>
+        <note>ID: MainWindow.Export.ExportFileSaveFileDlg.Caption</note>
       </trans-unit>
       <trans-unit id="MainWindow.LoadingProjectErrorMsg">
         <source xml:lang="en">{0} had a problem loading the {1} project. Please report this problem to the developers by clicking 'Details' below.</source>
-        <note>ID: MainWindow.LoadingProjectErrorMsg</note>
         <target xml:lang="es-ES" state="translated">{0} tuvo un problema al cargar el proyecto {1}. Favor de comunicar este problema a los programadores haciendo click en 'Detalles'.</target>
+        <note>ID: MainWindow.LoadingProjectErrorMsg</note>
       </trans-unit>
       <trans-unit id="MainWindow.ProblemOpeningSayMoreProject">
         <source xml:lang="en">There was a problem opening the SayMore project which might require that you restart your computer.</source>
-        <note>ID: MainWindow.ProblemOpeningSayMoreProject</note>
         <target xml:lang="es-ES" state="translated">Hubo un problema al abrir el proyecto SayMore que podría requerir que se reinicie el equipo.</target>
+        <note>ID: MainWindow.ProblemOpeningSayMoreProject</note>
       </trans-unit>
       <trans-unit id="MainWindow.ProblemSavingSayMoreProject">
         <source xml:lang="en">There was a problem saving the SayMore project:\n\n{0}</source>
-        <note>ID: MainWindow.ProblemSavingSayMoreProject</note>
         <target xml:lang="es-ES" state="translated">Hubo un problema al guardar el proyecto SayMore:\n\n{0}</target>
+        <note>ID: MainWindow.ProblemSavingSayMoreProject</note>
       </trans-unit>
       <trans-unit id="MainWindow.ProjectOpenInOtherSayMore">
         <source xml:lang="en">Another instance of SayMore is already open with this project:\n{0}\n\nIf you cannot find that instance of SayMore, restart your computer.</source>
-        <note>ID: MainWindow.ProjectOpenInOtherSayMore</note>
         <target xml:lang="es-ES" state="translated">Otra instancia de SayMore ya está abierto con este projecto:\n{0}\n\nSi usted no puede encontrar esa instancia de SayMore, reinicie el equipo.</target>
+        <note>ID: MainWindow.ProjectOpenInOtherSayMore</note>
       </trans-unit>
       <trans-unit id="MainWindow.RemovedElementsErrorMsg">
         <source xml:lang="en">The folders for the following elements have been removed from your computer.\nTherefore, SayMore will remove them from the list.\n\n{0}</source>
-        <note>ID: MainWindow.RemovedElementsErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Las carpetas de los siguientes elementos ya no existen.\nPor lo tanto, SayMore les eliminará de la lista.\n\n{0}</target>
+        <note>ID: MainWindow.RemovedElementsErrorMsg</note>
       </trans-unit>
       <trans-unit id="MainWindow.ViewTabsScrollLeftToolTipText">
         <source xml:lang="en">Scroll Left</source>
-        <note>ID: MainWindow.ViewTabsScrollLeftToolTipText</note>
         <target xml:lang="es-ES" state="translated">Desplazarse a la izquierda</target>
+        <note>ID: MainWindow.ViewTabsScrollLeftToolTipText</note>
       </trans-unit>
       <trans-unit id="MainWindow.ViewTabsScrollRightToolTipText">
         <source xml:lang="en">Scroll Right</source>
-        <note>ID: MainWindow.ViewTabsScrollRightToolTipText</note>
         <target xml:lang="es-ES" state="translated">Desplazarse a la derecha</target>
+        <note>ID: MainWindow.ViewTabsScrollRightToolTipText</note>
       </trans-unit>
       <trans-unit id="MainWindow.WaitingForOtherSayMoreInstance">
         <source xml:lang="en">Waiting for other instance of SayMore to finish...</source>
-        <note>ID: MainWindow.WaitingForOtherSayMoreInstance</note>
         <target xml:lang="es-ES" state="translated">Esperando que termine otra instancia de SayMore...</target>
+        <note>ID: MainWindow.WaitingForOtherSayMoreInstance</note>
       </trans-unit>
       <trans-unit id="MainWindow.WindowTitleWithProject">
         <source xml:lang="en">{0} - SayMore {1}.{2}.{3} {4}</source>
-        <note>ID: MainWindow.WindowTitleWithProject</note>
         <target xml:lang="es-ES" state="translated">{0} - SayMore {1}.{2}.{3} {4}</target>
+        <note>ID: MainWindow.WindowTitleWithProject</note>
       </trans-unit>
       <trans-unit id="MainWindow._mainMenuHelp">
         <source xml:lang="en">&amp;Help</source>
-        <note>ID: MainWindow._mainMenuHelp</note>
         <target xml:lang="es-ES" state="translated">A&amp;yuda</target>
+        <note>ID: MainWindow._mainMenuHelp</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuAbout">
         <source xml:lang="en">&amp;About...</source>
-        <note>ID: MainWindow._menuAbout</note>
         <target xml:lang="es-ES" state="translated">&amp;Acerca de SayMore...</target>
+        <note>ID: MainWindow._menuAbout</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuChangeUILanguage">
         <source xml:lang="en">&amp;Change User Interface Language...</source>
-        <note>ID: MainWindow._menuChangeUILanguage</note>
         <target xml:lang="es-ES" state="translated">Cambiar el idioma de la interfaz de usuario...</target>
+        <note>ID: MainWindow._menuChangeUILanguage</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuExit">
         <source xml:lang="en">E&amp;xit</source>
-        <note>ID: MainWindow._menuExit</note>
         <target xml:lang="es-ES" state="translated">Salir</target>
+        <note>ID: MainWindow._menuExit</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuExportPeople">
         <source xml:lang="en">Export &amp;People...</source>
-        <note>ID: MainWindow._menuExportPeople</note>
         <target xml:lang="es-ES" state="translated">Exportar información de personas...</target>
+        <note>ID: MainWindow._menuExportPeople</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuExportSessions">
         <source xml:lang="en">Export &amp;Sessions...</source>
-        <note>ID: MainWindow._menuExportSessions</note>
         <target xml:lang="es-ES" state="translated">Exportar sesiones...</target>
+        <note>ID: MainWindow._menuExportSessions</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuHelp">
         <source xml:lang="en">&amp;Help...</source>
-        <note>ID: MainWindow._menuHelp</note>
         <target xml:lang="es-ES" state="translated">&amp;Ayuda...</target>
+        <note>ID: MainWindow._menuHelp</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuOpenProject">
         <source xml:lang="en">&amp;Open/Create Project...</source>
-        <note>ID: MainWindow._menuOpenProject</note>
         <target xml:lang="es-ES" state="translated">&amp;Abrir o crear proyecto...</target>
+        <note>ID: MainWindow._menuOpenProject</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuProject">
         <source xml:lang="en">Pro&amp;ject</source>
-        <note>ID: MainWindow._menuProject</note>
         <target xml:lang="es-ES" state="translated">&amp;Proyecto</target>
+        <note>ID: MainWindow._menuProject</note>
       </trans-unit>
       <trans-unit id="MainWindow._menuReleaseNotes">
         <source xml:lang="en">Release &amp;Notes...</source>
-        <note>ID: MainWindow._menuReleaseNotes</note>
         <target xml:lang="es-ES" state="translated">Ver notas de la versión...</target>
+        <note>ID: MainWindow._menuReleaseNotes</note>
       </trans-unit>
       <trans-unit id="Miscellaneous.CopyFilesControl.CopyFailedMsg">
         <source xml:lang="en">Copying failed: {0}</source>
-        <note>ID: Miscellaneous.CopyFilesControl.CopyFailedMsg</note>
         <target xml:lang="es-ES" state="translated">Copiar servidor: {0}</target>
+        <note>ID: Miscellaneous.CopyFilesControl.CopyFailedMsg</note>
       </trans-unit>
       <trans-unit id="Miscellaneous.CopyFilesControl.CopyWaitingMsg">
         <source xml:lang="en">Waiting to start...</source>
-        <note>ID: Miscellaneous.CopyFilesControl.CopyWaitingMsg</note>
         <target xml:lang="es-ES" state="translated">A la espera de comenzar...</target>
+        <note>ID: Miscellaneous.CopyFilesControl.CopyWaitingMsg</note>
       </trans-unit>
       <trans-unit id="Miscellaneous.CopyFilesControl.CopyingFinishedMsg">
         <source xml:lang="en">Finished</source>
-        <note>ID: Miscellaneous.CopyFilesControl.CopyingFinishedMsg</note>
         <target xml:lang="es-ES" state="translated">Completado</target>
+        <note>ID: Miscellaneous.CopyFilesControl.CopyingFinishedMsg</note>
       </trans-unit>
       <trans-unit id="Miscellaneous.CopyFilesControl.CopyingProgressMsg">
         <source xml:lang="en">Copying {0} of {1} Files, ({2} of {3} Megabytes)</source>
-        <note>ID: Miscellaneous.CopyFilesControl.CopyingProgressMsg</note>
         <target xml:lang="es-ES" state="translated">Copiar {0} de {1} archivos, ({2} de {3} Megabytes)</target>
+        <note>ID: Miscellaneous.CopyFilesControl.CopyingProgressMsg</note>
       </trans-unit>
       <trans-unit id="Miscellaneous.CopyFilesControl.FileExistsMsg">
         <source xml:lang="en">The file '{0}' already exists</source>
-        <note>ID: Miscellaneous.CopyFilesControl.FileExistsMsg</note>
         <target xml:lang="es-ES" state="translated">El archivo '{0}' ya existe</target>
+        <note>ID: Miscellaneous.CopyFilesControl.FileExistsMsg</note>
       </trans-unit>
       <trans-unit id="Miscellaneous.CopyFilesControl.NoFilesToCopyMsg">
         <source xml:lang="en">No Files To Copy</source>
-        <note>ID: Miscellaneous.CopyFilesControl.NoFilesToCopyMsg</note>
         <target xml:lang="es-ES" state="translated">No hay archivos que copiar</target>
+        <note>ID: Miscellaneous.CopyFilesControl.NoFilesToCopyMsg</note>
       </trans-unit>
       <trans-unit id="Miscellaneous.CopyFilesControl.UnchangedFileMsg">
         <source xml:lang="en">The file {0} appears unchanged since it was copied before, so it will be skipped.</source>
-        <note>ID: Miscellaneous.CopyFilesControl.UnchangedFileMsg</note>
         <target xml:lang="es-ES" state="translated">El archivo {0} aparece sin cambios ya que estaba copiado antes, así que se omitirá.</target>
+        <note>ID: Miscellaneous.CopyFilesControl.UnchangedFileMsg</note>
       </trans-unit>
       <trans-unit id="Miscellaneous.PresetGathererNoPresetsYetMsg">
         <source xml:lang="en">No presets yet</source>
-        <note>ID: Miscellaneous.PresetGathererNoPresetsYetMsg</note>
         <target xml:lang="es-ES" state="translated">Todavía no hay ajustes preestablecidos</target>
+        <note>ID: Miscellaneous.PresetGathererNoPresetsYetMsg</note>
       </trans-unit>
       <trans-unit id="PeopleView.ContributionEditor.CommentColumnTitle">
         <source xml:lang="en">Comments</source>
-        <note>ID: PeopleView.ContributionEditor.CommentColumnTitle</note>
         <target xml:lang="es-ES" state="translated">Notas</target>
+        <note>ID: PeopleView.ContributionEditor.CommentColumnTitle</note>
       </trans-unit>
       <trans-unit id="PeopleView.ContributionEditor.DateColumnTitle">
         <source xml:lang="en">Date</source>
-        <note>ID: PeopleView.ContributionEditor.DateColumnTitle</note>
         <target xml:lang="es-ES" state="translated">Fecha</target>
+        <note>ID: PeopleView.ContributionEditor.DateColumnTitle</note>
       </trans-unit>
       <trans-unit id="PeopleView.ContributionEditor.NameColumnTitle">
         <source xml:lang="en">Name</source>
-        <note>ID: PeopleView.ContributionEditor.NameColumnTitle</note>
         <target xml:lang="es-ES" state="translated">Nombre</target>
+        <note>ID: PeopleView.ContributionEditor.NameColumnTitle</note>
       </trans-unit>
       <trans-unit id="PeopleView.ContributionEditor.RoleColumnTitle">
         <source xml:lang="en">Role</source>
-        <note>ID: PeopleView.ContributionEditor.RoleColumnTitle</note>
         <target xml:lang="es-ES" state="translated">Rol</target>
+        <note>ID: PeopleView.ContributionEditor.RoleColumnTitle</note>
       </trans-unit>
       <trans-unit id="PeopleView.ContributionEditor.RoleParticipant">
         <source xml:lang="en">Participant</source>
-        <note>ID: PeopleView.ContributionEditor.RoleParticipant</note>
         <target xml:lang="es-ES" state="translated">Participante</target>
+        <note>ID: PeopleView.ContributionEditor.RoleParticipant</note>
       </trans-unit>
       <trans-unit id="PeopleView.ContributionEditor.TabText">
         <source xml:lang="en">Contributions</source>
-        <note>ID: PeopleView.ContributionEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Contribuciones</target>
+        <note>ID: PeopleView.ContributionEditor.TabText</note>
       </trans-unit>
       <trans-unit id="PeopleView.FileList.AddPersonButtonToolTip">
         <source xml:lang="en">Add Files for the Person</source>
-        <note>ID: PeopleView.FileList.AddPersonButtonToolTip</note>
         <target xml:lang="es-ES" state="translated">Añadir archivos para la persona</target>
+        <note>ID: PeopleView.FileList.AddPersonButtonToolTip</note>
       </trans-unit>
       <trans-unit id="PeopleView.InformedConsentTypes.Audio">
         <source xml:lang="en">Informed Consent is Audio File</source>
-        <note>ID: PeopleView.InformedConsentTypes.Audio</note>
         <target xml:lang="es-ES" state="translated">El consentimiento informado está grabada en audio</target>
+        <note>ID: PeopleView.InformedConsentTypes.Audio</note>
       </trans-unit>
       <trans-unit id="PeopleView.InformedConsentTypes.None">
         <source xml:lang="en">No Informed Consent</source>
-        <note>ID: PeopleView.InformedConsentTypes.None</note>
         <target xml:lang="es-ES" state="translated">Sin consentimiento informado</target>
+        <note>ID: PeopleView.InformedConsentTypes.None</note>
       </trans-unit>
       <trans-unit id="PeopleView.InformedConsentTypes.Video">
         <source xml:lang="en">Informed Consent is Video File</source>
-        <note>ID: PeopleView.InformedConsentTypes.Video</note>
         <target xml:lang="es-ES" state="translated">El consentimiento informado está grabada en vídeo</target>
+        <note>ID: PeopleView.InformedConsentTypes.Video</note>
       </trans-unit>
       <trans-unit id="PeopleView.InformedConsentTypes.Written">
         <source xml:lang="en">Informed Consent is Written</source>
-        <note>ID: PeopleView.InformedConsentTypes.Written</note>
         <target xml:lang="es-ES" state="translated">Consentimiento informado está escrito</target>
+        <note>ID: PeopleView.InformedConsentTypes.Written</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.ChangePictureDlgCaption">
         <source xml:lang="en">Change Picture</source>
-        <note>ID: PeopleView.MetadataEditor.ChangePictureDlgCaption</note>
         <target xml:lang="es-ES" state="translated">Cambiar imágen</target>
+        <note>ID: PeopleView.MetadataEditor.ChangePictureDlgCaption</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.ErrorChangingPersonsPhotoMsg">
         <source xml:lang="en">There was an error changing the person's photo.</source>
-        <note>ID: PeopleView.MetadataEditor.ErrorChangingPersonsPhotoMsg</note>
         <target xml:lang="es-ES" state="translated">Un error ocurrió al intentar de cambiar la foto de la persona.</target>
+        <note>ID: PeopleView.MetadataEditor.ErrorChangingPersonsPhotoMsg</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.ErrorLoadingPersonsPhotoMsg">
         <source xml:lang="en">There was an error loading the person's photo.</source>
-        <note>ID: PeopleView.MetadataEditor.ErrorLoadingPersonsPhotoMsg</note>
         <target xml:lang="es-ES" state="translated">Un error ocurrió al intentar de cargar la foto de la persona.</target>
+        <note>ID: PeopleView.MetadataEditor.ErrorLoadingPersonsPhotoMsg</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.FatherSelectorToolTip.WhenNotSelected">
         <source xml:lang="en">Click to indicate this is the father's primary language</source>
-        <note>ID: PeopleView.MetadataEditor.FatherSelectorToolTip.WhenNotSelected</note>
         <target xml:lang="es-ES" state="translated">Seleccionar para indicar que esto es el idioma principal del padre</target>
+        <note>ID: PeopleView.MetadataEditor.FatherSelectorToolTip.WhenNotSelected</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.FatherSelectorToolTip.WhenSelected">
         <source xml:lang="en">Indicates this is the father's primary language</source>
-        <note>ID: PeopleView.MetadataEditor.FatherSelectorToolTip.WhenSelected</note>
         <target xml:lang="es-ES" state="translated">Indica que se trata del idioma principal del padre</target>
+        <note>ID: PeopleView.MetadataEditor.FatherSelectorToolTip.WhenSelected</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.GenderSelector.Female">
         <source xml:lang="en">Female</source>
-        <note>ID: PeopleView.MetadataEditor.GenderSelector.Female</note>
         <target xml:lang="es-ES" state="translated">Hembra</target>
+        <note>ID: PeopleView.MetadataEditor.GenderSelector.Female</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.GenderSelector.Male">
         <source xml:lang="en">Male</source>
-        <note>ID: PeopleView.MetadataEditor.GenderSelector.Male</note>
         <target xml:lang="es-ES" state="translated">Macho</target>
+        <note>ID: PeopleView.MetadataEditor.GenderSelector.Male</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.ImageFileTypes">
         <source xml:lang="en">JPEG Images (*.jpg)|*.jpg|GIF Images (*.gif)|*.gif|TIFF Images (*.tif)|*.tif|PNG Images (*.png)|*.png|Bitmaps (*.bmp;*.dib)|*.bmp;*.dib|All Files (*.*)|*.*</source>
-        <note>ID: PeopleView.MetadataEditor.ImageFileTypes</note>
         <target xml:lang="es-ES" state="translated">Imágenes JPEG (*.jpg) |*.jpg|Imágenes GIF (*.gif)|*.gif|Imágenes TIFF (*.tif) |*.tif|Imágenes PNG (*.png)|*.png|Mapas de bits (*.bmp; *.dib) |*.bmp;*.dib|Todos los archivos (*.*)|*.*</target>
+        <note>ID: PeopleView.MetadataEditor.ImageFileTypes</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.MotherSelectorToolTip.WhenNotSelected">
         <source xml:lang="en">Click to indicate this is the mother's primary language</source>
-        <note>ID: PeopleView.MetadataEditor.MotherSelectorToolTip.WhenNotSelected</note>
         <target xml:lang="es-ES" state="translated">Seleccionar para indicar que esto es el idioma principal de la madre</target>
+        <note>ID: PeopleView.MetadataEditor.MotherSelectorToolTip.WhenNotSelected</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.MotherSelectorToolTip.WhenSelected">
         <source xml:lang="en">Indicates this is the mother's primary language</source>
-        <note>ID: PeopleView.MetadataEditor.MotherSelectorToolTip.WhenSelected</note>
         <target xml:lang="es-ES" state="translated">Indica que se trata del idioma principal de la madre</target>
+        <note>ID: PeopleView.MetadataEditor.MotherSelectorToolTip.WhenSelected</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor.TabText">
         <source xml:lang="en">Person</source>
-        <note>ID: PeopleView.MetadataEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Persona</target>
+        <note>ID: PeopleView.MetadataEditor.TabText</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelBirthYear">
         <source xml:lang="en">Birth &amp;Year</source>
-        <note>ID: PeopleView.MetadataEditor._labelBirthYear</note>
         <target xml:lang="es-ES" state="translated">Año de naci&amp;miento</target>
+        <note>ID: PeopleView.MetadataEditor._labelBirthYear</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelCustomFields">
         <source xml:lang="en">&amp;Custom Fields</source>
-        <note>ID: PeopleView.MetadataEditor._labelCustomFields</note>
         <target xml:lang="es-ES" state="translated">&amp;Campos definidos por el usario</target>
+        <note>ID: PeopleView.MetadataEditor._labelCustomFields</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelEducation">
         <source xml:lang="en">&amp;Education</source>
-        <note>ID: PeopleView.MetadataEditor._labelEducation</note>
         <target xml:lang="es-ES" state="translated">E&amp;ducación</target>
+        <note>ID: PeopleView.MetadataEditor._labelEducation</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelEthnicGroup">
         <source xml:lang="en">Ethnic Gro&amp;up</source>
-        <note>ID: PeopleView.MetadataEditor._labelEthnicGroup</note>
         <target xml:lang="es-ES" state="translated">Gr&amp;upo étnico</target>
+        <note>ID: PeopleView.MetadataEditor._labelEthnicGroup</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelFullName">
         <source xml:lang="en">&amp;Full Name</source>
-        <note>ID: PeopleView.MetadataEditor._labelFullName</note>
         <target xml:lang="es-ES" state="translated">&amp;Nombre completo</target>
+        <note>ID: PeopleView.MetadataEditor._labelFullName</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelHowToContact">
         <source xml:lang="en">Ho&amp;w to Contact</source>
-        <note>ID: PeopleView.MetadataEditor._labelHowToContact</note>
         <target xml:lang="es-ES" state="translated">In&amp;formación de contacto</target>
+        <note>ID: PeopleView.MetadataEditor._labelHowToContact</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelID">
         <source xml:lang="en">Co&amp;de</source>
-        <note>ID: PeopleView.MetadataEditor._labelID</note>
         <target xml:lang="es-ES" state="translated">Código &amp;ID</target>
+        <note>ID: PeopleView.MetadataEditor._labelID</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelNickName">
         <source xml:lang="en">Nic&amp;kname</source>
-        <note>ID: PeopleView.MetadataEditor._labelNickName</note>
         <target xml:lang="es-ES" state="translated">So&amp;brenombre</target>
+        <note>ID: PeopleView.MetadataEditor._labelNickName</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelOtherLanguages">
         <source xml:lang="en">Other L&amp;anguages</source>
-        <note>ID: PeopleView.MetadataEditor._labelOtherLanguages</note>
         <target xml:lang="es-ES" state="translated">O&amp;tros idiomas</target>
+        <note>ID: PeopleView.MetadataEditor._labelOtherLanguages</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelPrimaryLanguage">
         <source xml:lang="en">Primary &amp;Language</source>
-        <note>ID: PeopleView.MetadataEditor._labelPrimaryLanguage</note>
         <target xml:lang="es-ES" state="translated">Idioma principa&amp;l</target>
+        <note>ID: PeopleView.MetadataEditor._labelPrimaryLanguage</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelPrimaryLanguageLearnedIn">
         <source xml:lang="en">Learned &amp;In:</source>
-        <note>ID: PeopleView.MetadataEditor._labelPrimaryLanguageLearnedIn</note>
         <target xml:lang="es-ES" state="translated">Lugar de aprendi&amp;zaje:</target>
+        <note>ID: PeopleView.MetadataEditor._labelPrimaryLanguageLearnedIn</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelPrimaryOccupation">
         <source xml:lang="en">Primary &amp;Occupation</source>
-        <note>ID: PeopleView.MetadataEditor._labelPrimaryOccupation</note>
         <target xml:lang="es-ES" state="translated">&amp;Ocupación principal</target>
+        <note>ID: PeopleView.MetadataEditor._labelPrimaryOccupation</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelPrivacyProtection">
         <source xml:lang="en">Archive should keep this person private</source>
-        <note>ID: PeopleView.MetadataEditor._labelPrivacyProtection</note>
         <target xml:lang="es-ES" state="translated">Protección de la privacidad</target>
+        <note>ID: PeopleView.MetadataEditor._labelPrivacyProtection</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._labelgender">
         <source xml:lang="en">&amp;Gender</source>
-        <note>ID: PeopleView.MetadataEditor._labelgender</note>
         <target xml:lang="es-ES" state="translated">&amp;Género</target>
+        <note>ID: PeopleView.MetadataEditor._labelgender</note>
       </trans-unit>
       <trans-unit id="PeopleView.MetadataEditor._personsPicture_ToolTip_">
         <source xml:lang="en">Click to Change Picture</source>
-        <note>ID: PeopleView.MetadataEditor._personsPicture_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Hacer clic para cambiar la imagen</target>
+        <note>ID: PeopleView.MetadataEditor._personsPicture_ToolTip_</note>
       </trans-unit>
       <trans-unit id="PeopleView.Miscellaneous.AlreadyExistsSaveFailureMessage">
         <source xml:lang="en">Could not rename from {0} to {1} because there is already a person by that name.</source>
-        <note>ID: PeopleView.Miscellaneous.AlreadyExistsSaveFailureMessage</note>
         <target xml:lang="es-ES" state="translated">No se pudo cambiar el nombre de {0} a {1} porque ya hay una persona con ese nombre.</target>
+        <note>ID: PeopleView.Miscellaneous.AlreadyExistsSaveFailureMessage</note>
       </trans-unit>
       <trans-unit id="PeopleView.Miscellaneous.NewPersonNamePrefix">
         <source xml:lang="en">New Person</source>
-        <note>ID: PeopleView.Miscellaneous.NewPersonNamePrefix</note>
         <target xml:lang="es-ES" state="translated">Nueva persona</target>
+        <note>ID: PeopleView.Miscellaneous.NewPersonNamePrefix</note>
       </trans-unit>
       <trans-unit id="PeopleView.Miscellaneous.NoIdSaveFailureMessage">
         <source xml:lang="en">You must specify a name.</source>
-        <note>ID: PeopleView.Miscellaneous.NoIdSaveFailureMessage</note>
         <target xml:lang="es-ES" state="translated">Debe especificar un nombre.</target>
+        <note>ID: PeopleView.Miscellaneous.NoIdSaveFailureMessage</note>
       </trans-unit>
       <trans-unit id="PeopleView.PeopleList.ClickNewButtonHelpPrompt">
         <source xml:lang="en">Click 'New' to add a new person.</source>
-        <note>ID: PeopleView.PeopleList.ClickNewButtonHelpPrompt</note>
         <target xml:lang="es-ES" state="translated">Haga clic en Añadir para agregar a una nueva persona.</target>
+        <note>ID: PeopleView.PeopleList.ClickNewButtonHelpPrompt</note>
       </trans-unit>
       <trans-unit id="PeopleView.PeopleList.ColumnHeadings.Consent">
         <source xml:lang="en">Consent</source>
-        <note>ID: PeopleView.PeopleList.ColumnHeadings.Consent</note>
         <target xml:lang="es-ES" state="translated">Consentimiento</target>
+        <note>ID: PeopleView.PeopleList.ColumnHeadings.Consent</note>
       </trans-unit>
       <trans-unit id="PeopleView.PeopleList.ColumnHeadings.Person">
         <source xml:lang="en">Person</source>
-        <note>ID: PeopleView.PeopleList.ColumnHeadings.Person</note>
         <target xml:lang="es-ES" state="translated">Persona</target>
+        <note>ID: PeopleView.PeopleList.ColumnHeadings.Person</note>
       </trans-unit>
       <trans-unit id="PeopleView.PeopleList.HeadingText">
         <source xml:lang="en">People</source>
-        <note>ID: PeopleView.PeopleList.HeadingText</note>
         <target xml:lang="es-ES" state="translated">Personas</target>
+        <note>ID: PeopleView.PeopleList.HeadingText</note>
       </trans-unit>
       <trans-unit id="PeopleView.PeopleMainMenu.NewMenuText">
         <source xml:lang="en">&amp;New</source>
-        <note>ID: PeopleView.PeopleMainMenu.NewMenuText</note>
         <target xml:lang="es-ES" state="translated">&amp;Añadir otra persona</target>
+        <note>ID: PeopleView.PeopleMainMenu.NewMenuText</note>
       </trans-unit>
       <trans-unit id="PeopleView.PeopleMainMenu.TopLevelMenuText">
         <source xml:lang="en">&amp;Person</source>
-        <note>ID: PeopleView.PeopleMainMenu.TopLevelMenuText</note>
         <target xml:lang="es-ES" state="translated">P&amp;ersona</target>
+        <note>ID: PeopleView.PeopleMainMenu.TopLevelMenuText</note>
       </trans-unit>
       <trans-unit id="PeopleView.ViewTabText">
         <source xml:lang="en">People</source>
-        <note>ID: PeopleView.ViewTabText</note>
         <target xml:lang="es-ES" state="translated">Personas</target>
+        <note>ID: PeopleView.ViewTabText</note>
       </trans-unit>
       <trans-unit id="PeopleView.ViewTabText_ToolTip_">
         <source xml:lang="en">People View</source>
-        <note>ID: PeopleView.ViewTabText_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Vista de personas</target>
+        <note>ID: PeopleView.ViewTabText_ToolTip_</note>
       </trans-unit>
       <trans-unit id="ProgressView.ByGenreHeadingText">
         <source xml:lang="en">By Genre</source>
-        <note>ID: ProgressView.ByGenreHeadingText</note>
         <target xml:lang="es-ES" state="translated">Por Género</target>
+        <note>ID: ProgressView.ByGenreHeadingText</note>
       </trans-unit>
       <trans-unit id="ProgressView.ByStagesHeadingText">
         <source xml:lang="en">Completed Stages</source>
-        <note>ID: ProgressView.ByStagesHeadingText</note>
         <target xml:lang="es-ES" state="translated">Por Etapas</target>
+        <note>ID: ProgressView.ByStagesHeadingText</note>
       </trans-unit>
       <trans-unit id="ProgressView.CopyMenuItemText">
         <source xml:lang="en">&amp;Copy</source>
-        <note>ID: ProgressView.CopyMenuItemText</note>
         <target xml:lang="es-ES" state="translated">&amp;Copiar</target>
+        <note>ID: ProgressView.CopyMenuItemText</note>
       </trans-unit>
       <trans-unit id="ProgressView.CopyMenuItemText_ToolTip_">
         <source xml:lang="en">Copy entire view to clipboard</source>
-        <note>ID: ProgressView.CopyMenuItemText_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Copiar vista entera al Portapapeles</target>
+        <note>ID: ProgressView.CopyMenuItemText_ToolTip_</note>
       </trans-unit>
       <trans-unit id="ProgressView.HeadingText">
         <source xml:lang="en">SayMore statistics for {0}</source>
-        <note>ID: ProgressView.HeadingText</note>
-        <note>Parameter is project name.</note>
         <target xml:lang="es-ES" state="translated">Estadísticas de SayMore para {0}</target>
+        <note>ID: ProgressView.HeadingText</note>
       </trans-unit>
       <trans-unit id="ProgressView.OverviewHeadingText">
         <source xml:lang="en">Overview</source>
-        <note>ID: ProgressView.OverviewHeadingText</note>
         <target xml:lang="es-ES" state="translated">Resumen</target>
+        <note>ID: ProgressView.OverviewHeadingText</note>
       </trans-unit>
       <trans-unit id="ProgressView.PeopleLabel">
         <source xml:lang="en">People:</source>
-        <note>ID: ProgressView.PeopleLabel</note>
         <target xml:lang="es-ES" state="translated">Personas:</target>
+        <note>ID: ProgressView.PeopleLabel</note>
       </trans-unit>
       <trans-unit id="ProgressView.PrintMenuItemText">
         <source xml:lang="en">&amp;Print...</source>
-        <note>ID: ProgressView.PrintMenuItemText</note>
         <target xml:lang="es-ES" state="translated">Im&amp;primir...</target>
+        <note>ID: ProgressView.PrintMenuItemText</note>
       </trans-unit>
       <trans-unit id="ProgressView.ProgressMainMenuItemText">
         <source xml:lang="en">Pr&amp;ogress</source>
-        <note>ID: ProgressView.ProgressMainMenuItemText</note>
         <target xml:lang="es-ES" state="translated">Pr&amp;ogreso</target>
+        <note>ID: ProgressView.ProgressMainMenuItemText</note>
       </trans-unit>
       <trans-unit id="ProgressView.SaveMenuItemText">
         <source xml:lang="en">&amp;Save...</source>
-        <note>ID: ProgressView.SaveMenuItemText</note>
         <target xml:lang="es-ES" state="translated">Guardar...</target>
+        <note>ID: ProgressView.SaveMenuItemText</note>
       </trans-unit>
       <trans-unit id="ProgressView.SaveMenuItemText_ToolTip_">
         <source xml:lang="en">Save view to file</source>
-        <note>ID: ProgressView.SaveMenuItemText_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Guardar reporte de progreso</target>
+        <note>ID: ProgressView.SaveMenuItemText_ToolTip_</note>
       </trans-unit>
       <trans-unit id="ProgressView.SessionsLabel">
         <source xml:lang="en">Sessions:</source>
-        <note>ID: ProgressView.SessionsLabel</note>
         <target xml:lang="es-ES" state="translated">Sesiones:</target>
+        <note>ID: ProgressView.SessionsLabel</note>
       </trans-unit>
       <trans-unit id="ProgressView.SummaryTotalsTextForOneBar">
         <source xml:lang="en">{0} sessions totaling {1}</source>
-        <note>ID: ProgressView.SummaryTotalsTextForOneBar</note>
         <target xml:lang="es-ES" state="translated">{0} sesiones con duración total de {1} minutos</target>
+        <note>ID: ProgressView.SummaryTotalsTextForOneBar</note>
       </trans-unit>
       <trans-unit id="ProgressView.SummaryTotalsTextForSegment1">
         <source xml:lang="en">{0}{1} sessions totaling {2}</source>
-        <note>ID: ProgressView.SummaryTotalsTextForSegment1</note>
         <target xml:lang="es-ES" state="translated">{0}{1} sesiones con duración total de {2} minutos</target>
+        <note>ID: ProgressView.SummaryTotalsTextForSegment1</note>
       </trans-unit>
       <trans-unit id="ProgressView.SummaryTotalsTextForSegment2">
         <source xml:lang="en">{0}: {1} sessions totaling {2}</source>
-        <note>ID: ProgressView.SummaryTotalsTextForSegment2</note>
         <target xml:lang="es-ES" state="translated">{0}: {1} sesiones con duración total de {2} minutos</target>
+        <note>ID: ProgressView.SummaryTotalsTextForSegment2</note>
       </trans-unit>
       <trans-unit id="Project.FontCreationError">
         <source xml:lang="en">An error occurred trying to create the {0} font from settings: {1}</source>
-        <note>ID: Project.FontCreationError</note>
-        <note>Param 0: name of setting or description of font being created;Param 1: settings string used to attempt to create the font (This is essentially human-readable, but it will not be localized, since it is a string the computer interprets.)</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al intentar crear la fuente {0} desde la configuración: {1}</target>
+        <note>ID: Project.FontCreationError</note>
       </trans-unit>
       <trans-unit id="Project.FontCreationFallback">
         <source xml:lang="en">A font with the specified font family was successfully created using a fallback size. Please examine the font settings and choose a suitable font. If after doing so, you continue to see this warning, please send in this report.</source>
-        <note>ID: Project.FontCreationFallback</note>
         <target xml:lang="es-ES" state="translated">Una fuente con la familia de fuentes especificada se creó correctamente usando un tamaño de retroceso. Por favor, examine la configuración de la fuente y elija una fuente adecuada. Si después de hacerlo, continúa viendo esta advertencia, por favor envíe este informe.</target>
+        <note>ID: Project.FontCreationFallback</note>
       </trans-unit>
       <trans-unit id="Project.FreeTranslationFontDescription">
         <source xml:lang="en">Free Translation</source>
-        <note>ID: Project.FreeTranslationFontDescription</note>
-        <note>Used as a parameter in Project.FontCreationError</note>
         <target xml:lang="es-ES" state="translated">traducción libre</target>
+        <note>ID: Project.FreeTranslationFontDescription</note>
       </trans-unit>
       <trans-unit id="Project.TranscriptionFontDescription">
         <source xml:lang="en">Transcription</source>
-        <note>ID: Project.TranscriptionFontDescription</note>
-        <note>Used as a parameter in Project.FontCreationError</note>
         <target xml:lang="es-ES" state="translated">transcripción</target>
+        <note>ID: Project.TranscriptionFontDescription</note>
       </trans-unit>
       <trans-unit id="ProjectView.AboutProjectViewTitle">
         <source xml:lang="en">About This Project</source>
-        <note>ID: ProjectView.AboutProjectViewTitle</note>
         <target xml:lang="es-ES" state="translated">Acerca de este proyecto</target>
+        <note>ID: ProjectView.AboutProjectViewTitle</note>
       </trans-unit>
       <trans-unit id="ProjectView.AccessProtocolViewTitle">
         <source xml:lang="en">Access Protocol</source>
-        <note>ID: ProjectView.AccessProtocolViewTitle</note>
         <target xml:lang="es-ES" state="translated">Protocolo de acceso</target>
+        <note>ID: ProjectView.AccessProtocolViewTitle</note>
       </trans-unit>
       <trans-unit id="ProjectView.AccessScreen.Custom">
         <source xml:lang="en">Custom</source>
-        <note>ID: ProjectView.AccessScreen.Custom</note>
         <target xml:lang="es-ES" state="translated">Personalizado</target>
+        <note>ID: ProjectView.AccessScreen.Custom</note>
       </trans-unit>
       <trans-unit id="ProjectView.AccessScreen.None">
         <source xml:lang="en">None</source>
-        <note>ID: ProjectView.AccessScreen.None</note>
         <target xml:lang="es-ES" state="translated">Ninguno</target>
+        <note>ID: ProjectView.AccessScreen.None</note>
       </trans-unit>
       <trans-unit id="ProjectView.AccessScreen._labelAccessProtocol">
         <source xml:lang="en">Access Protocol used\nby this project</source>
-        <note>ID: ProjectView.AccessScreen._labelAccessProtocol</note>
         <target xml:lang="es-ES" state="translated">Protocolo de acceso usado\npor este proyecto</target>
+        <note>ID: ProjectView.AccessScreen._labelAccessProtocol</note>
       </trans-unit>
       <trans-unit id="ProjectView.AccessScreen._labelCustomAccessInstructions">
         <source xml:lang="en">Enter each choice, separated by commas</source>
-        <note>ID: ProjectView.AccessScreen._labelCustomAccessInstructions</note>
         <target xml:lang="es-ES" state="translated">Escriba las opciones separadas por comas.</target>
+        <note>ID: ProjectView.AccessScreen._labelCustomAccessInstructions</note>
       </trans-unit>
       <trans-unit id="ProjectView.AccessScreen._labelDescription">
         <source xml:lang="en">Custom Access Choices</source>
-        <note>ID: ProjectView.AccessScreen._labelDescription</note>
         <target xml:lang="es-ES" state="translated">Opciones de acceso personalizadas</target>
+        <note>ID: ProjectView.AccessScreen._labelDescription</note>
       </trans-unit>
       <trans-unit id="ProjectView.AccessScreen._linkHelp">
         <source xml:lang="en">Help for access protocols</source>
-        <note>ID: ProjectView.AccessScreen._linkHelp</note>
         <target xml:lang="es-ES" state="translated">Ayuda para los protocolos de acceso</target>
+        <note>ID: ProjectView.AccessScreen._linkHelp</note>
       </trans-unit>
       <trans-unit id="ProjectView.DescriptionDocuments._linkHowArchived">
         <source xml:lang="en">How these are archived</source>
-        <note>ID: ProjectView.DescriptionDocuments._linkHowArchived</note>
         <target xml:lang="es-ES" state="translated">Cómo son archivadas</target>
+        <note>ID: ProjectView.DescriptionDocuments._linkHowArchived</note>
       </trans-unit>
       <trans-unit id="ProjectView.DescriptionDocumentsTitle">
         <source xml:lang="en">Description Documents</source>
-        <note>ID: ProjectView.DescriptionDocumentsTitle</note>
         <target xml:lang="es-ES" state="translated">Documentos descriptivos</target>
+        <note>ID: ProjectView.DescriptionDocumentsTitle</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelAddress">
         <source xml:lang="en">A&amp;ddress</source>
-        <note>ID: ProjectView.MetadataScreen._labelAddress</note>
         <target xml:lang="es-ES" state="translated">&amp;Dirección</target>
+        <note>ID: ProjectView.MetadataScreen._labelAddress</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelContact">
         <source xml:lang="en">Co&amp;ntact</source>
-        <note>ID: ProjectView.MetadataScreen._labelContact</note>
         <target xml:lang="es-ES" state="translated">Co&amp;ntacto</target>
+        <note>ID: ProjectView.MetadataScreen._labelContact</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelContinent">
         <source xml:lang="en">Con&amp;tinent</source>
-        <note>ID: ProjectView.MetadataScreen._labelContinent</note>
         <target xml:lang="es-ES" state="translated">Continente</target>
+        <note>ID: ProjectView.MetadataScreen._labelContinent</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelCountry">
         <source xml:lang="en">Countr&amp;y</source>
-        <note>ID: ProjectView.MetadataScreen._labelCountry</note>
         <target xml:lang="es-ES" state="translated">País</target>
+        <note>ID: ProjectView.MetadataScreen._labelCountry</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelDateAvailable">
         <source xml:lang="en">Avai&amp;lable On</source>
-        <note>ID: ProjectView.MetadataScreen._labelDateAvailable</note>
         <target xml:lang="es-ES" state="translated">Fecha disponible</target>
+        <note>ID: ProjectView.MetadataScreen._labelDateAvailable</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelDepositor">
         <source xml:lang="en">D&amp;epositor</source>
-        <note>ID: ProjectView.MetadataScreen._labelDepositor</note>
         <target xml:lang="es-ES" state="translated">Depositante</target>
+        <note>ID: ProjectView.MetadataScreen._labelDepositor</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelDescription">
         <source xml:lang="en">Desc&amp;ription</source>
-        <note>ID: ProjectView.MetadataScreen._labelDescription</note>
         <target xml:lang="es-ES" state="translated">Descripción</target>
+        <note>ID: ProjectView.MetadataScreen._labelDescription</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelFundingProject">
         <source xml:lang="en">&amp;Funding Project</source>
-        <note>ID: ProjectView.MetadataScreen._labelFundingProject</note>
         <target xml:lang="es-ES" state="translated">&amp;Financiación del proyecto</target>
+        <note>ID: ProjectView.MetadataScreen._labelFundingProject</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelMainLocation">
         <source xml:lang="en">Main Location</source>
-        <note>ID: ProjectView.MetadataScreen._labelMainLocation</note>
         <target xml:lang="es-ES" state="translated">Lugar principal</target>
+        <note>ID: ProjectView.MetadataScreen._labelMainLocation</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelProjectBasics">
         <source xml:lang="en">Project Basics</source>
-        <note>ID: ProjectView.MetadataScreen._labelProjectBasics</note>
         <target xml:lang="es-ES" state="translated">Elementos básicos del Proyecto</target>
+        <note>ID: ProjectView.MetadataScreen._labelProjectBasics</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelProjectTitle">
         <source xml:lang="en">&amp;Title</source>
-        <note>ID: ProjectView.MetadataScreen._labelProjectTitle</note>
         <target xml:lang="es-ES" state="translated">&amp;Título</target>
+        <note>ID: ProjectView.MetadataScreen._labelProjectTitle</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelRegion">
         <source xml:lang="en">Re&amp;gion</source>
-        <note>ID: ProjectView.MetadataScreen._labelRegion</note>
         <target xml:lang="es-ES" state="translated">Re&amp;gión</target>
+        <note>ID: ProjectView.MetadataScreen._labelRegion</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelResponsibilities">
         <source xml:lang="en">Responsibilities</source>
-        <note>ID: ProjectView.MetadataScreen._labelResponsibilities</note>
         <target xml:lang="es-ES" state="translated">Responsabilidades</target>
+        <note>ID: ProjectView.MetadataScreen._labelResponsibilities</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelRightsHolder">
         <source xml:lang="en">R&amp;ights Holder</source>
-        <note>ID: ProjectView.MetadataScreen._labelRightsHolder</note>
         <target xml:lang="es-ES" state="translated">Titular de los derechos</target>
+        <note>ID: ProjectView.MetadataScreen._labelRightsHolder</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelsubDate">
         <source xml:lang="en">date</source>
-        <note>ID: ProjectView.MetadataScreen._labelsubDate</note>
         <target xml:lang="es-ES" state="translated">fecha</target>
+        <note>ID: ProjectView.MetadataScreen._labelsubDate</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelsubLikeStateOrProvince">
         <source xml:lang="en">like state or province</source>
-        <note>ID: ProjectView.MetadataScreen._labelsubLikeStateOrProvince</note>
         <target xml:lang="es-ES" state="translated">estado o provincia, etc.</target>
+        <note>ID: ProjectView.MetadataScreen._labelsubLikeStateOrProvince</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelsubOfTheProject">
         <source xml:lang="en">of the project</source>
-        <note>ID: ProjectView.MetadataScreen._labelsubOfTheProject</note>
         <target xml:lang="es-ES" state="translated">del proyecto</target>
+        <note>ID: ProjectView.MetadataScreen._labelsubOfTheProject</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelsubOrSimilar">
         <source xml:lang="en">or similar</source>
-        <note>ID: ProjectView.MetadataScreen._labelsubOrSimilar</note>
         <target xml:lang="es-ES" state="translated">o similar</target>
+        <note>ID: ProjectView.MetadataScreen._labelsubOrSimilar</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelsubPerson1">
         <source xml:lang="en">person</source>
-        <note>ID: ProjectView.MetadataScreen._labelsubPerson1</note>
         <target xml:lang="es-ES" state="translated">persona</target>
+        <note>ID: ProjectView.MetadataScreen._labelsubPerson1</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelsubPerson2">
         <source xml:lang="en">person</source>
-        <note>ID: ProjectView.MetadataScreen._labelsubPerson2</note>
         <target xml:lang="es-ES" state="translated">persona</target>
+        <note>ID: ProjectView.MetadataScreen._labelsubPerson2</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelsubPerson3">
         <source xml:lang="en">person</source>
-        <note>ID: ProjectView.MetadataScreen._labelsubPerson3</note>
         <target xml:lang="es-ES" state="translated">persona</target>
+        <note>ID: ProjectView.MetadataScreen._labelsubPerson3</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._labelsubTitle">
         <source xml:lang="en">title</source>
-        <note>ID: ProjectView.MetadataScreen._labelsubTitle</note>
         <target xml:lang="es-ES" state="translated">título</target>
+        <note>ID: ProjectView.MetadataScreen._labelsubTitle</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._linkHelp">
         <source xml:lang="en">Help for these fields</source>
-        <note>ID: ProjectView.MetadataScreen._linkHelp</note>
         <target xml:lang="es-ES" state="translated">Ayuda para estos campos</target>
+        <note>ID: ProjectView.MetadataScreen._linkHelp</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._linkSelectContentLanguage">
         <source xml:lang="en">Content Language</source>
-        <note>ID: ProjectView.MetadataScreen._linkSelectContentLanguage</note>
         <target xml:lang="es-ES" state="translated">Idioma del contenido</target>
+        <note>ID: ProjectView.MetadataScreen._linkSelectContentLanguage</note>
       </trans-unit>
       <trans-unit id="ProjectView.MetadataScreen._linkSelectWorkingLanguage">
         <source xml:lang="en">Working Language</source>
-        <note>ID: ProjectView.MetadataScreen._linkSelectWorkingLanguage</note>
         <target xml:lang="es-ES" state="translated">Idioma de investigación</target>
+        <note>ID: ProjectView.MetadataScreen._linkSelectWorkingLanguage</note>
       </trans-unit>
       <trans-unit id="ProjectView.OtherDocumentsTitle">
         <source xml:lang="en">Other Documents</source>
-        <note>ID: ProjectView.OtherDocumentsTitle</note>
         <target xml:lang="es-ES" state="translated">Otros documentos</target>
+        <note>ID: ProjectView.OtherDocumentsTitle</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProgressScreen._buttonCopy">
         <source xml:lang="en">Copy</source>
-        <note>ID: ProjectView.ProgressScreen._buttonCopy</note>
         <target xml:lang="es-ES" state="translated">Copiar</target>
+        <note>ID: ProjectView.ProgressScreen._buttonCopy</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProgressScreen._buttonPrint">
         <source xml:lang="en">Print</source>
-        <note>ID: ProjectView.ProgressScreen._buttonPrint</note>
         <target xml:lang="es-ES" state="translated">Imprimir</target>
+        <note>ID: ProjectView.ProgressScreen._buttonPrint</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProgressScreen._buttonRefresh">
         <source xml:lang="en">&amp;Refresh</source>
-        <note>ID: ProjectView.ProgressScreen._buttonRefresh</note>
         <target xml:lang="es-ES" state="translated">Actualizar</target>
+        <note>ID: ProjectView.ProgressScreen._buttonRefresh</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProgressScreen._buttonRefresh_ToolTip_">
         <source xml:lang="en">Refresh View</source>
-        <note>ID: ProjectView.ProgressScreen._buttonRefresh_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Actualizar vista</target>
+        <note>ID: ProjectView.ProgressScreen._buttonRefresh_ToolTip_</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProgressScreen._buttonSave">
         <source xml:lang="en">Save</source>
-        <note>ID: ProjectView.ProgressScreen._buttonSave</note>
         <target xml:lang="es-ES" state="translated">Guardar</target>
+        <note>ID: ProjectView.ProgressScreen._buttonSave</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProgressScreen._labelWorking">
         <source xml:lang="en">Working...</source>
-        <note>ID: ProjectView.ProgressScreen._labelWorking</note>
         <target xml:lang="es-ES" state="translated">Trabajando...</target>
+        <note>ID: ProjectView.ProgressScreen._labelWorking</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProgressViewTitle">
         <source xml:lang="en">Progress</source>
-        <note>ID: ProjectView.ProgressViewTitle</note>
         <target xml:lang="es-ES" state="translated">Progreso</target>
+        <note>ID: ProjectView.ProgressViewTitle</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProjectDocuments.AddDescriptionFileToolTip">
         <source xml:lang="en">Add Description Documents to the Project</source>
-        <note>ID: ProjectView.ProjectDocuments.AddDescriptionFileToolTip</note>
         <target xml:lang="es-ES" state="translated">Agregar documentos descriptivos al proyecto</target>
+        <note>ID: ProjectView.ProjectDocuments.AddDescriptionFileToolTip</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProjectDocuments.AddOtherFileToolTip">
         <source xml:lang="en">Add Other Documents to the Project</source>
-        <note>ID: ProjectView.ProjectDocuments.AddOtherFileToolTip</note>
         <target xml:lang="es-ES" state="translated">Agregar al proyecto otros documentos</target>
+        <note>ID: ProjectView.ProjectDocuments.AddOtherFileToolTip</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProjectDocuments.DescriptionDocumentsInformationLabel">
         <source xml:lang="en">Add documents here that describe the project and corpus.</source>
-        <note>ID: ProjectView.ProjectDocuments.DescriptionDocumentsInformationLabel</note>
         <target xml:lang="es-ES" state="translated">Agregar aquí los documentos que describen el proyecto y el corpus.</target>
+        <note>ID: ProjectView.ProjectDocuments.DescriptionDocumentsInformationLabel</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProjectDocuments.HowArchivedMsg">
         <source xml:lang="en">In an IMDI project archive, these files will be exported in a special session named {0}</source>
-        <note>ID: ProjectView.ProjectDocuments.HowArchivedMsg</note>
         <target xml:lang="es-ES" state="translated">Al archivar el proyecto a IMDI , estos archivos se exportarán en una sesión especial llamada {0}</target>
+        <note>ID: ProjectView.ProjectDocuments.HowArchivedMsg</note>
       </trans-unit>
       <trans-unit id="ProjectView.ProjectDocuments.OtherDocumentsInformationLabel">
         <source xml:lang="en">Add documents here that don't seem to fit anywhere else, for example about how the project was funded.</source>
-        <note>ID: ProjectView.ProjectDocuments.OtherDocumentsInformationLabel</note>
         <target xml:lang="es-ES" state="translated">Agregar documentos aquí que no pertenecen en otro lugar (por ejemplo, documentos con información sobre el financiamiento del proyecto).</target>
+        <note>ID: ProjectView.ProjectDocuments.OtherDocumentsInformationLabel</note>
       </trans-unit>
       <trans-unit id="ProjectView.TabText">
         <source xml:lang="en">Project</source>
-        <note>ID: ProjectView.TabText</note>
         <target xml:lang="es-ES" state="translated">Proyecto</target>
+        <note>ID: ProjectView.TabText</note>
       </trans-unit>
       <trans-unit id="ProjectView.TabText_ToolTip_">
         <source xml:lang="en">Project View</source>
-        <note>ID: ProjectView.TabText_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">vista del proyecto</target>
+        <note>ID: ProjectView.TabText_ToolTip_</note>
       </trans-unit>
       <trans-unit id="ProjectWindow.archiveRAMPProjectToolStripMenuItem">
         <source xml:lang="en">&amp;Archive with RAMP (SIL)...</source>
-        <note>ID: ProjectWindow.archiveRAMPProjectToolStripMenuItem</note>
         <target xml:lang="es-ES" state="translated">&amp;Archivar con RAMP (ILV)...</target>
+        <note>ID: ProjectWindow.archiveRAMPProjectToolStripMenuItem</note>
       </trans-unit>
       <trans-unit id="ProjectWindow.archiveUsingIMDIToolStripMenuItem">
         <source xml:lang="en">&amp;Archive using IMDI...</source>
-        <note>ID: ProjectWindow.archiveUsingIMDIToolStripMenuItem</note>
         <target xml:lang="es-ES" state="translated">&amp;Archivar con IMDI...</target>
+        <note>ID: ProjectWindow.archiveUsingIMDIToolStripMenuItem</note>
       </trans-unit>
       <trans-unit id="SessionsView.ContributorsEditor.CommentColumnTitle">
         <source xml:lang="en">Comments</source>
-        <note>ID: SessionsView.ContributorsEditor.CommentColumnTitle</note>
         <target xml:lang="es-ES" state="translated">Notas</target>
+        <note>ID: SessionsView.ContributorsEditor.CommentColumnTitle</note>
       </trans-unit>
       <trans-unit id="SessionsView.ContributorsEditor.DateColumnTitle">
         <source xml:lang="en">Date</source>
-        <note>ID: SessionsView.ContributorsEditor.DateColumnTitle</note>
         <target xml:lang="es-ES" state="translated">Fecha</target>
+        <note>ID: SessionsView.ContributorsEditor.DateColumnTitle</note>
       </trans-unit>
       <trans-unit id="SessionsView.ContributorsEditor.NameColumnTitle">
         <source xml:lang="en">Name</source>
-        <note>ID: SessionsView.ContributorsEditor.NameColumnTitle</note>
         <target xml:lang="es-ES" state="translated">Nombre</target>
+        <note>ID: SessionsView.ContributorsEditor.NameColumnTitle</note>
       </trans-unit>
       <trans-unit id="SessionsView.ContributorsEditor.RoleColumnTitle">
         <source xml:lang="en">Role</source>
-        <note>ID: SessionsView.ContributorsEditor.RoleColumnTitle</note>
         <target xml:lang="es-ES" state="translated">Papel</target>
+        <note>ID: SessionsView.ContributorsEditor.RoleColumnTitle</note>
       </trans-unit>
       <trans-unit id="SessionsView.FileList.AddSessionsButtonToolTip">
         <source xml:lang="en">Add Files to the Session</source>
-        <note>ID: SessionsView.FileList.AddSessionsButtonToolTip</note>
         <target xml:lang="es-ES" state="translated">Agregar archivos a la sesión</target>
+        <note>ID: SessionsView.FileList.AddSessionsButtonToolTip</note>
       </trans-unit>
       <trans-unit id="SessionsView.GeneratedOralAnnotationView.CarefulLabel">
         <source xml:lang="en">Careful</source>
-        <note>ID: SessionsView.GeneratedOralAnnotationView.CarefulLabel</note>
         <target xml:lang="es-ES" state="translated">Cuidadosa</target>
+        <note>ID: SessionsView.GeneratedOralAnnotationView.CarefulLabel</note>
       </trans-unit>
       <trans-unit id="SessionsView.GeneratedOralAnnotationView.SourceLabel">
         <source xml:lang="en">Source</source>
-        <note>ID: SessionsView.GeneratedOralAnnotationView.SourceLabel</note>
         <target xml:lang="es-ES" state="translated">Original</target>
+        <note>ID: SessionsView.GeneratedOralAnnotationView.SourceLabel</note>
       </trans-unit>
       <trans-unit id="SessionsView.GeneratedOralAnnotationView.TranslationLabel">
         <source xml:lang="en">Translation</source>
-        <note>ID: SessionsView.GeneratedOralAnnotationView.TranslationLabel</note>
         <target xml:lang="es-ES" state="translated">Traducción</target>
+        <note>ID: SessionsView.GeneratedOralAnnotationView.TranslationLabel</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILCA." sil:dynamic="true">
+        <source xml:lang="en">only the Depositor and delegate can access</source>
+        <target xml:lang="es-ES" state="needs-translation">only the Depositor and delegate can access</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILCA.</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILCA.C" sil:dynamic="true">
+        <source xml:lang="en">only Community members are allowed access (normally requires application to Depositor)</source>
+        <target xml:lang="es-ES" state="needs-translation">only Community members are allowed access (normally requires application to Depositor)</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILCA.C</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILCA.F" sil:dynamic="true">
+        <source xml:lang="en">access is Free to all</source>
+        <target xml:lang="es-ES" state="needs-translation">access is Free to all</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILCA.F</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILCA.RC" sil:dynamic="true">
+        <source xml:lang="en">Researchers and Community members are allowed access</source>
+        <target xml:lang="es-ES" state="needs-translation">Researchers and Community members are allowed access</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILCA.RC</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILCA.S" sil:dynamic="true">
+        <source xml:lang="en">only Subscribers are allowed access (requires application to Depositor)</source>
+        <target xml:lang="es-ES" state="needs-translation">only Subscribers are allowed access (requires application to Depositor)</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILCA.S</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILCA.U" sil:dynamic="true">
+        <source xml:lang="en">all Users can access (requires registration)</source>
+        <target xml:lang="es-ES" state="translated">Todos los usuarios pueden acceder (requiere registro)</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILCA.U</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 1" sil:dynamic="true">
+        <source xml:lang="en">Public Access</source>
+        <target xml:lang="es-ES" state="translated">Acceso público</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 1</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 2" sil:dynamic="true">
+        <source xml:lang="en">Password</source>
+        <target xml:lang="es-ES" state="translated">Contraseña</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 2</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 3" sil:dynamic="true">
+        <source xml:lang="en">Time limit</source>
+        <target xml:lang="es-ES" state="needs-translation">Time limit</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 3</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 4" sil:dynamic="true">
+        <source xml:lang="en">Depositor control</source>
+        <target xml:lang="es-ES" state="needs-translation">Depositor control</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 4</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.ELAR.O" sil:dynamic="true">
         <source xml:lang="en">Open to unregistered visitors</source>
-        <note>ID: SessionsView.MetadataEditor.AccessProtocol.ELAR.O</note>
         <target xml:lang="es-ES" state="translated">Accesible a visitantes no registrados</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.ELAR.O</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.ELAR.S" sil:dynamic="true">
         <source xml:lang="en">only Subscribers are allowed access (requires application to Depositor)</source>
-        <note>ID: SessionsView.MetadataEditor.AccessProtocol.ELAR.S</note>
         <target xml:lang="es-ES" state="translated">solo los suscriptores pueden acceder (se requiere llenar una solicitud al depositador)</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.ELAR.S</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.ELAR.U" sil:dynamic="true">
         <source xml:lang="en">all ordinary Users can access</source>
-        <note>ID: SessionsView.MetadataEditor.AccessProtocol.ELAR.U</note>
         <target xml:lang="es-ES" state="translated">todos los usuarios normales pueden acceder</target>
+        <note>ID: SessionsView.MetadataEditor.AccessProtocol.ELAR.U</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Interactivity" sil:dynamic="true">
+        <source xml:lang="en">Interactivity</source>
+        <target xml:lang="es-ES" state="translated">Interactividad</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Interactivity</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Involvement">
         <source xml:lang="en">Researcher Involvement</source>
-        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Involvement</note>
         <target xml:lang="es-ES" state="translated">Participación</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Involvement</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Location Address" sil:dynamic="true">
         <source xml:lang="en">Location Address</source>
-        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Location Address</note>
         <target xml:lang="es-ES" state="translated">Dirección</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Location Address</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Location Continent" sil:dynamic="true">
         <source xml:lang="en">Location Continent</source>
-        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Location Continent</note>
         <target xml:lang="es-ES" state="translated">Continente</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Location Continent</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Location Country" sil:dynamic="true">
         <source xml:lang="en">Location Country</source>
-        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Location Country</note>
         <target xml:lang="es-ES" state="translated">País</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Location Country</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Location Region" sil:dynamic="true">
         <source xml:lang="en">Location Region</source>
-        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Location Region</note>
         <target xml:lang="es-ES" state="translated">Región</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Location Region</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Planning Type" sil:dynamic="true">
         <source xml:lang="en">Planning Type</source>
-        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Planning Type</note>
         <target xml:lang="es-ES" state="translated">Tipo de planeamiento</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Planning Type</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Social Context" sil:dynamic="true">
         <source xml:lang="en">Social Context</source>
-        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Social Context</note>
         <target xml:lang="es-ES" state="translated">Contexto social</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Social Context</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Sub-Genre" sil:dynamic="true">
         <source xml:lang="en">Sub-Genre</source>
-        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Sub-Genre</note>
         <target xml:lang="es-ES" state="translated">Sub-género</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Sub-Genre</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.MetadataEditor.AdditionalFields.Task" sil:dynamic="true">
+        <source xml:lang="en">Task</source>
+        <target xml:lang="es-ES" state="translated">Tarea</target>
+        <note>ID: SessionsView.MetadataEditor.AdditionalFields.Task</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.drama" sil:dynamic="true">
         <source xml:lang="en">Drama</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.drama</note>
         <target xml:lang="es-ES" state="translated">Drama</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.drama</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.formulaic_discourse" sil:dynamic="true">
         <source xml:lang="en">Formulaic Discourse</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.formulaic_discourse</note>
         <target xml:lang="es-ES" state="translated">Discurso de fórmula</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.formulaic_discourse</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.instrumental_music" sil:dynamic="true">
         <source xml:lang="en">Instrumental Music</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.instrumental_music</note>
         <target xml:lang="es-ES" state="translated">Música instrumental</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.instrumental_music</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.interactive_discourse" sil:dynamic="true">
         <source xml:lang="en">Interactive Discourse</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.interactive_discourse</note>
         <target xml:lang="es-ES" state="translated">Discurso interactivo</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.interactive_discourse</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.language_play" sil:dynamic="true">
         <source xml:lang="en">Language Play</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.language_play</note>
         <target xml:lang="es-ES" state="translated">Lenguaje de Juego</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.language_play</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.narrative" sil:dynamic="true">
         <source xml:lang="en">Narrative</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.narrative</note>
         <target xml:lang="es-ES" state="translated">Narrativa</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.narrative</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.oratory" sil:dynamic="true">
         <source xml:lang="en">Oratory</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.oratory</note>
         <target xml:lang="es-ES" state="translated">Oratorio</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.oratory</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.procedural_discourse" sil:dynamic="true">
         <source xml:lang="en">Procedural Discourse</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.procedural_discourse</note>
         <target xml:lang="es-ES" state="translated">Discurso de procedimiento</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.procedural_discourse</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.report" sil:dynamic="true">
         <source xml:lang="en">Report</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.report</note>
         <target xml:lang="es-ES" state="translated">Informe</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.report</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.singing" sil:dynamic="true">
         <source xml:lang="en">Singing</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.singing</note>
         <target xml:lang="es-ES" state="translated">Canto</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.singing</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.Genre.unintelligible_speech" sil:dynamic="true">
         <source xml:lang="en">Unintelligible Speech</source>
-        <note>ID: SessionsView.MetadataEditor.Genre.unintelligible_speech</note>
         <target xml:lang="es-ES" state="translated">Habla ininteligible</target>
+        <note>ID: SessionsView.MetadataEditor.Genre.unintelligible_speech</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.TabText">
         <source xml:lang="en">Session</source>
-        <note>ID: SessionsView.MetadataEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Sesión</target>
+        <note>ID: SessionsView.MetadataEditor.TabText</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.UnknownGenre">
         <source xml:lang="en">&lt;Unknown&gt;</source>
-        <note>ID: SessionsView.MetadataEditor.UnknownGenre</note>
-        <note>Unknown genre displayed in the genre drop-down list.</note>
         <target xml:lang="es-ES" state="translated">&lt;Desconocido&gt;</target>
+        <note>ID: SessionsView.MetadataEditor.UnknownGenre</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelAccess">
         <source xml:lang="en">&amp;Access</source>
-        <note>ID: SessionsView.MetadataEditor._labelAccess</note>
         <target xml:lang="es-ES" state="translated">Acces&amp;o</target>
+        <note>ID: SessionsView.MetadataEditor._labelAccess</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelCustomFields">
         <source xml:lang="en">&amp;Custom Fields</source>
-        <note>ID: SessionsView.MetadataEditor._labelCustomFields</note>
         <target xml:lang="es-ES" state="translated">&amp;Campos definidos por el usuario</target>
+        <note>ID: SessionsView.MetadataEditor._labelCustomFields</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelDate">
         <source xml:lang="en">&amp;Date</source>
-        <note>ID: SessionsView.MetadataEditor._labelDate</note>
         <target xml:lang="es-ES" state="translated">&amp;Fecha</target>
+        <note>ID: SessionsView.MetadataEditor._labelDate</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelDescription">
         <source xml:lang="en">Desc&amp;ription</source>
-        <note>ID: SessionsView.MetadataEditor._labelDescription</note>
         <target xml:lang="es-ES" state="translated">&amp;Descripción</target>
+        <note>ID: SessionsView.MetadataEditor._labelDescription</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelGenre">
         <source xml:lang="en">&amp;Genre</source>
-        <note>ID: SessionsView.MetadataEditor._labelGenre</note>
         <target xml:lang="es-ES" state="translated">&amp;Género</target>
+        <note>ID: SessionsView.MetadataEditor._labelGenre</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelId">
         <source xml:lang="en">&amp;ID</source>
-        <note>ID: SessionsView.MetadataEditor._labelId</note>
         <target xml:lang="es-ES" state="translated">&amp;ID</target>
+        <note>ID: SessionsView.MetadataEditor._labelId</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelLocation">
         <source xml:lang="en">&amp;Location</source>
-        <note>ID: SessionsView.MetadataEditor._labelLocation</note>
         <target xml:lang="es-ES" state="translated">&amp;Lugar</target>
+        <note>ID: SessionsView.MetadataEditor._labelLocation</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelMoreFields">
         <source xml:lang="en">&amp;More Fields</source>
-        <note>ID: SessionsView.MetadataEditor._labelMoreFields</note>
         <target xml:lang="es-ES" state="translated">&amp;Más campos</target>
+        <note>ID: SessionsView.MetadataEditor._labelMoreFields</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelParticipants">
         <source xml:lang="en">Pe&amp;ople</source>
-        <note>ID: SessionsView.MetadataEditor._labelParticipants</note>
         <target xml:lang="es-ES" state="translated">Pe&amp;rsonas</target>
+        <note>ID: SessionsView.MetadataEditor._labelParticipants</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelSetting">
         <source xml:lang="en">S&amp;etting</source>
-        <note>ID: SessionsView.MetadataEditor._labelSetting</note>
         <target xml:lang="es-ES" state="translated">Esce&amp;na</target>
+        <note>ID: SessionsView.MetadataEditor._labelSetting</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelSituation">
         <source xml:lang="en">Sit&amp;uation</source>
-        <note>ID: SessionsView.MetadataEditor._labelSituation</note>
         <target xml:lang="es-ES" state="translated">Sit&amp;uación</target>
+        <note>ID: SessionsView.MetadataEditor._labelSituation</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor._labelTitle">
         <source xml:lang="en">&amp;Title</source>
-        <note>ID: SessionsView.MetadataEditor._labelTitle</note>
         <target xml:lang="es-ES" state="translated">&amp;Título</target>
+        <note>ID: SessionsView.MetadataEditor._labelTitle</note>
       </trans-unit>
       <trans-unit id="SessionsView.Miscellaneous.NewSessionNamePrefix">
         <source xml:lang="en">New Session</source>
-        <note>ID: SessionsView.Miscellaneous.NewSessionNamePrefix</note>
         <target xml:lang="es-ES" state="translated">Nueva Sesión</target>
+        <note>ID: SessionsView.Miscellaneous.NewSessionNamePrefix</note>
       </trans-unit>
       <trans-unit id="SessionsView.Miscellaneous.NoIdSaveFailureMessage">
         <source xml:lang="en">You must specify a session id.</source>
-        <note>ID: SessionsView.Miscellaneous.NoIdSaveFailureMessage</note>
         <target xml:lang="es-ES" state="translated">Debe especificarse un ID para la sesión.</target>
+        <note>ID: SessionsView.Miscellaneous.NoIdSaveFailureMessage</note>
       </trans-unit>
       <trans-unit id="SessionsView.Miscellaneous.SessionAlreadyExistsSaveFailureMessage">
         <source xml:lang="en">Could not rename from {0} to {1} because there is already a session by that name.</source>
-        <note>ID: SessionsView.Miscellaneous.SessionAlreadyExistsSaveFailureMessage</note>
         <target xml:lang="es-ES" state="translated">No se pudo cambiar el nombre de {0} a {1} porque existe una sesión con el mismo nombre.</target>
+        <note>ID: SessionsView.Miscellaneous.SessionAlreadyExistsSaveFailureMessage</note>
       </trans-unit>
       <trans-unit id="SessionsView.MissingMediaFileEditor.TabText">
         <source xml:lang="en">Missing Media File</source>
-        <note>ID: SessionsView.MissingMediaFileEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Falta el archivo multimedia</target>
+        <note>ID: SessionsView.MissingMediaFileEditor.TabText</note>
       </trans-unit>
       <trans-unit id="SessionsView.MissingMediaFileEditor.lblExplanation">
         <source xml:lang="en">This can happen if the media file is inadvertently deleted or renamed outside of SayMore. It could also happen if a properly named ELAN file is added to a SayMore session but internally refers to a media file that is not where SayMore expects to find it. If you have access to the media file and would like to be able to annotate it in SayMore, please copy it to the above location.</source>
-        <note>ID: SessionsView.MissingMediaFileEditor.lblExplanation</note>
         <target xml:lang="es-ES" state="translated">Esto puede ocurrir al eliminar o cambiar el nombre del archivo multimedia por error fuera de SayMore. También puede ocurrir si un archivo de ELAN se añade a una sesión en SayMore el cual se refiere internamente a un archivo multimedia que no está donde SayMore espera encontrarlo. Si usted tiene acceso al archivo multimedia y desea anotarlo en SayMore, favor de copiarlo en el lugar mencionado anteriormente.</target>
+        <note>ID: SessionsView.MissingMediaFileEditor.lblExplanation</note>
       </trans-unit>
       <trans-unit id="SessionsView.MissingMediaFileEditor.lblMediaFileMissing">
         <source xml:lang="en">The media file for this ELAN file could not be found. SayMore expected to find it here:</source>
-        <note>ID: SessionsView.MissingMediaFileEditor.lblMediaFileMissing</note>
         <target xml:lang="es-ES" state="translated">No se encuentra el archivo multimedia para este archivo ELAN. SayMore espera encontrarlo aquí:</target>
+        <note>ID: SessionsView.MissingMediaFileEditor.lblMediaFileMissing</note>
       </trans-unit>
       <trans-unit id="SessionsView.MissingMediaFileEditor.linkHelpTopic">
         <source xml:lang="en">Show Help topic for ELAN</source>
-        <note>ID: SessionsView.MissingMediaFileEditor.linkHelpTopic</note>
         <target xml:lang="es-ES" state="translated">Mostrar el tema de ayuda para ELAN</target>
+        <note>ID: SessionsView.MissingMediaFileEditor.linkHelpTopic</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionStatus.Finished">
         <source xml:lang="en">Finished</source>
-        <note>ID: SessionsView.SessionStatus.Finished</note>
         <target xml:lang="es-ES" state="translated">Completado</target>
+        <note>ID: SessionsView.SessionStatus.Finished</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionStatus.InProgress">
         <source xml:lang="en">In Progress</source>
-        <note>ID: SessionsView.SessionStatus.InProgress</note>
         <target xml:lang="es-ES" state="translated">En curso</target>
+        <note>ID: SessionsView.SessionStatus.InProgress</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionStatus.Incoming">
         <source xml:lang="en">Incoming</source>
-        <note>ID: SessionsView.SessionStatus.Incoming</note>
         <target xml:lang="es-ES" state="translated">Nuevamente añadido</target>
+        <note>ID: SessionsView.SessionStatus.Incoming</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionStatus.Skipped">
         <source xml:lang="en">Skipped</source>
-        <note>ID: SessionsView.SessionStatus.Skipped</note>
         <target xml:lang="es-ES" state="translated">Omitido</target>
+        <note>ID: SessionsView.SessionStatus.Skipped</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionStatus.TooltipFormatText">
         <source xml:lang="en">Status: {0}</source>
-        <note>ID: SessionsView.SessionStatus.TooltipFormatText</note>
         <target xml:lang="es-ES" state="translated">Estado: {0}</target>
+        <note>ID: SessionsView.SessionStatus.TooltipFormatText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.ClickNewButtonHelpPrompt">
         <source xml:lang="en">Click 'New' to add a new session.</source>
-        <note>ID: SessionsView.SessionsList.ClickNewButtonHelpPrompt</note>
         <target xml:lang="es-ES" state="translated">Haga clic en Añadir para agregar una nueva sesión.</target>
+        <note>ID: SessionsView.SessionsList.ClickNewButtonHelpPrompt</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.ColumnHeadings.Date">
         <source xml:lang="en">Date</source>
-        <note>ID: SessionsView.SessionsList.ColumnHeadings.Date</note>
         <target xml:lang="es-ES" state="translated">Fecha</target>
+        <note>ID: SessionsView.SessionsList.ColumnHeadings.Date</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.ColumnHeadings.Genre">
         <source xml:lang="en">Genre</source>
-        <note>ID: SessionsView.SessionsList.ColumnHeadings.Genre</note>
         <target xml:lang="es-ES" state="translated">Género</target>
+        <note>ID: SessionsView.SessionsList.ColumnHeadings.Genre</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.ColumnHeadings.Id">
         <source xml:lang="en">Id</source>
-        <note>ID: SessionsView.SessionsList.ColumnHeadings.Id</note>
         <target xml:lang="es-ES" state="translated">ID</target>
+        <note>ID: SessionsView.SessionsList.ColumnHeadings.Id</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.ColumnHeadings.Location">
         <source xml:lang="en">Location</source>
-        <note>ID: SessionsView.SessionsList.ColumnHeadings.Location</note>
         <target xml:lang="es-ES" state="translated">Lugar</target>
+        <note>ID: SessionsView.SessionsList.ColumnHeadings.Location</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.ColumnHeadings.Stages">
         <source xml:lang="en">Stages</source>
-        <note>ID: SessionsView.SessionsList.ColumnHeadings.Stages</note>
         <target xml:lang="es-ES" state="translated">Etapas</target>
+        <note>ID: SessionsView.SessionsList.ColumnHeadings.Stages</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.ColumnHeadings.Status">
         <source xml:lang="en">Status</source>
-        <note>ID: SessionsView.SessionsList.ColumnHeadings.Status</note>
         <target xml:lang="es-ES" state="translated">Estado</target>
+        <note>ID: SessionsView.SessionsList.ColumnHeadings.Status</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.ColumnHeadings.Title">
         <source xml:lang="en">Title</source>
-        <note>ID: SessionsView.SessionsList.ColumnHeadings.Title</note>
         <target xml:lang="es-ES" state="translated">Título</target>
+        <note>ID: SessionsView.SessionsList.ColumnHeadings.Title</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.HeadingText">
         <source xml:lang="en">Sessions</source>
-        <note>ID: SessionsView.SessionsList.HeadingText</note>
         <target xml:lang="es-ES" state="translated">Sesiones</target>
+        <note>ID: SessionsView.SessionsList.HeadingText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.IMDIArchiveMenuText">
         <source xml:lang="en">Archive using &amp;IMDI...</source>
-        <note>ID: SessionsView.SessionsList.IMDIArchiveMenuText</note>
         <target xml:lang="es-ES" state="translated">Archivar con IMDI...</target>
+        <note>ID: SessionsView.SessionsList.IMDIArchiveMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.NewFilesFromDeviceButtonText">
         <source xml:lang="en">New From De&amp;vice...</source>
-        <note>ID: SessionsView.SessionsList.NewFilesFromDeviceButtonText</note>
         <target xml:lang="es-ES" state="translated">Crear sesión con archivos del dispositivo...</target>
+        <note>ID: SessionsView.SessionsList.NewFilesFromDeviceButtonText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.NewFilesFromRecordingButtonText">
         <source xml:lang="en">New From &amp;Recording...</source>
-        <note>ID: SessionsView.SessionsList.NewFilesFromRecordingButtonText</note>
         <target xml:lang="es-ES" state="translated">Crear sesión de una nueva grabación...</target>
+        <note>ID: SessionsView.SessionsList.NewFilesFromRecordingButtonText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.RampArchiveMenuText">
         <source xml:lang="en">Archive with RAMP (&amp;SIL)...</source>
-        <note>ID: SessionsView.SessionsList.RampArchiveMenuText</note>
         <target xml:lang="es-ES" state="translated">&amp;Archivar con RAMP (ILV)...</target>
+        <note>ID: SessionsView.SessionsList.RampArchiveMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.Stages.CarefulSpeech">
         <source xml:lang="en">Careful Speech</source>
-        <note>ID: SessionsView.SessionsList.Stages.CarefulSpeech</note>
         <target xml:lang="es-ES" state="translated">Habla cuidadosa</target>
+        <note>ID: SessionsView.SessionsList.Stages.CarefulSpeech</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.Stages.CompleteToolTipText">
         <source xml:lang="en">Complete</source>
-        <note>ID: SessionsView.SessionsList.Stages.CompleteToolTipText</note>
         <target xml:lang="es-ES" state="translated">Completo</target>
+        <note>ID: SessionsView.SessionsList.Stages.CompleteToolTipText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.Stages.IncompleteToolTipText">
         <source xml:lang="en">Incomplete</source>
-        <note>ID: SessionsView.SessionsList.Stages.IncompleteToolTipText</note>
         <target xml:lang="es-ES" state="translated">Incompleto</target>
+        <note>ID: SessionsView.SessionsList.Stages.IncompleteToolTipText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.Stages.InformedConsent">
         <source xml:lang="en">Informed Consent</source>
-        <note>ID: SessionsView.SessionsList.Stages.InformedConsent</note>
         <target xml:lang="es-ES" state="translated">Consentimiento informado</target>
+        <note>ID: SessionsView.SessionsList.Stages.InformedConsent</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.Stages.OralTranslation">
         <source xml:lang="en">Oral Translation</source>
-        <note>ID: SessionsView.SessionsList.Stages.OralTranslation</note>
         <target xml:lang="es-ES" state="translated">Traducción oral</target>
+        <note>ID: SessionsView.SessionsList.Stages.OralTranslation</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.Stages.SourceRecording">
         <source xml:lang="en">Source Recording</source>
-        <note>ID: SessionsView.SessionsList.Stages.SourceRecording</note>
         <target xml:lang="es-ES" state="translated">Grabación original</target>
+        <note>ID: SessionsView.SessionsList.Stages.SourceRecording</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.Stages.Transcription">
         <source xml:lang="en">Transcription</source>
-        <note>ID: SessionsView.SessionsList.Stages.Transcription</note>
         <target xml:lang="es-ES" state="translated">Transcripción</target>
+        <note>ID: SessionsView.SessionsList.Stages.Transcription</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsList.Stages.WrittenTranslation">
         <source xml:lang="en">Written Translation</source>
-        <note>ID: SessionsView.SessionsList.Stages.WrittenTranslation</note>
         <target xml:lang="es-ES" state="translated">Traducción escrita</target>
+        <note>ID: SessionsView.SessionsList.Stages.WrittenTranslation</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsMainMenu.NewFromDeviceMenuText">
         <source xml:lang="en">New From De&amp;vice...</source>
-        <note>ID: SessionsView.SessionsMainMenu.NewFromDeviceMenuText</note>
         <target xml:lang="es-ES" state="translated">Crear sesión con archi&amp;vos del dispositivo...</target>
+        <note>ID: SessionsView.SessionsMainMenu.NewFromDeviceMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsMainMenu.NewFromRecordingMenuText">
         <source xml:lang="en">New From &amp;Recording...</source>
-        <note>ID: SessionsView.SessionsMainMenu.NewFromRecordingMenuText</note>
         <target xml:lang="es-ES" state="translated">C&amp;rear sesión de una nueva grabación...</target>
+        <note>ID: SessionsView.SessionsMainMenu.NewFromRecordingMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsMainMenu.NewMenuText">
         <source xml:lang="en">&amp;New</source>
-        <note>ID: SessionsView.SessionsMainMenu.NewMenuText</note>
         <target xml:lang="es-ES" state="translated">&amp;Añadir una nueva sesión</target>
+        <note>ID: SessionsView.SessionsMainMenu.NewMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.SessionsMainMenu.TopLevelMenuText">
         <source xml:lang="en">&amp;Session</source>
-        <note>ID: SessionsView.SessionsMainMenu.TopLevelMenuText</note>
         <target xml:lang="es-ES" state="translated">&amp;Sesión</target>
+        <note>ID: SessionsView.SessionsMainMenu.TopLevelMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor.StageNameDisplayFormat">
         <source xml:lang="en">{0} (on auto-pilot)</source>
-        <note>ID: SessionsView.StatusAndStagesEditor.StageNameDisplayFormat</note>
         <target xml:lang="es-ES" state="translated">{0} (automático)</target>
+        <note>ID: SessionsView.StatusAndStagesEditor.StageNameDisplayFormat</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor.StatusToolTips.Finished">
         <source xml:lang="en">I'm done working on it.</source>
-        <note>ID: SessionsView.StatusAndStagesEditor.StatusToolTips.Finished</note>
         <target xml:lang="es-ES" state="translated">No hay más trabajo que hacer en esta sesión.</target>
+        <note>ID: SessionsView.StatusAndStagesEditor.StatusToolTips.Finished</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor.StatusToolTips.In_Progress">
         <source xml:lang="en">I'm working on it.</source>
-        <note>ID: SessionsView.StatusAndStagesEditor.StatusToolTips.In_Progress</note>
         <target xml:lang="es-ES" state="translated">Trabajo en esta sesión está en curso.</target>
+        <note>ID: SessionsView.StatusAndStagesEditor.StatusToolTips.In_Progress</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor.StatusToolTips.Incoming">
         <source xml:lang="en">I am gathering the recording and meta\ndata and may or may not take it further.</source>
-        <note>ID: SessionsView.StatusAndStagesEditor.StatusToolTips.Incoming</note>
         <target xml:lang="es-ES" state="translated">Todavía se están reuniendo las grabaciones y metadatos para\nesta sesión, con la posibilidad de ampliarse en el futuro.</target>
+        <note>ID: SessionsView.StatusAndStagesEditor.StatusToolTips.Incoming</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor.StatusToolTips.Skipped">
         <source xml:lang="en">I've decided to not develop\nthis session at this time.</source>
-        <note>ID: SessionsView.StatusAndStagesEditor.StatusToolTips.Skipped</note>
         <target xml:lang="es-ES" state="translated">Por el momento, no hay intenciones de seguir desarollando esta sesión.</target>
+        <note>ID: SessionsView.StatusAndStagesEditor.StatusToolTips.Skipped</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor.TabText">
         <source xml:lang="en">Status &amp;&amp; Stages</source>
-        <note>ID: SessionsView.StatusAndStagesEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Estado y etapas</target>
+        <note>ID: SessionsView.StatusAndStagesEditor.TabText</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor._labelReadAboutStages">
         <source xml:lang="en">Read About SayMore Stages</source>
-        <note>ID: SessionsView.StatusAndStagesEditor._labelReadAboutStages</note>
         <target xml:lang="es-ES" state="translated">Lea sobre las etapas en SayMore</target>
+        <note>ID: SessionsView.StatusAndStagesEditor._labelReadAboutStages</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor._labelReadAboutStatus">
         <source xml:lang="en">Read About SayMore Status Indicators</source>
-        <note>ID: SessionsView.StatusAndStagesEditor._labelReadAboutStatus</note>
         <target xml:lang="es-ES" state="translated">Lea sobre indicadores de estado en SayMore</target>
+        <note>ID: SessionsView.StatusAndStagesEditor._labelReadAboutStatus</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor._labelStages">
         <source xml:lang="en">Stages</source>
-        <note>ID: SessionsView.StatusAndStagesEditor._labelStages</note>
         <target xml:lang="es-ES" state="translated">Etapas</target>
+        <note>ID: SessionsView.StatusAndStagesEditor._labelStages</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor._labelStagesHint">
         <source xml:lang="en">Stages are normally automatic indicators of what  has been done, based on file names and annotation work you've done. Click any item to take control of this indicator.</source>
-        <note>ID: SessionsView.StatusAndStagesEditor._labelStagesHint</note>
         <target xml:lang="es-ES" state="translated">Las etapas normalmente indican automáticamente el progreso realizado. SayMore usa los nombres de los archivos y la presecia de anotaciones para determinar cuales etapas se han completado. Presione cualquier elemento para tomar el control manual de este indicador.</target>
+        <note>ID: SessionsView.StatusAndStagesEditor._labelStagesHint</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor._labelStatus">
         <source xml:lang="en">Status</source>
-        <note>ID: SessionsView.StatusAndStagesEditor._labelStatus</note>
         <target xml:lang="es-ES" state="translated">Estado</target>
+        <note>ID: SessionsView.StatusAndStagesEditor._labelStatus</note>
       </trans-unit>
       <trans-unit id="SessionsView.StatusAndStagesEditor._labelStatusHint">
         <source xml:lang="en">Use the status to mark the big picture of this session.</source>
-        <note>ID: SessionsView.StatusAndStagesEditor._labelStatusHint</note>
         <target xml:lang="es-ES" state="translated">Indique el estado general de esta sesión.</target>
+        <note>ID: SessionsView.StatusAndStagesEditor._labelStatusHint</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.AnnotationFileNotFoundMsg">
         <source xml:lang="en">File not found: '{0}'</source>
-        <note>ID: SessionsView.Transcription.AnnotationFileNotFoundMsg</note>
         <target xml:lang="es-ES" state="translated">Archivo no encontrado: '{0}'</target>
+        <note>ID: SessionsView.Transcription.AnnotationFileNotFoundMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.BadAnnotationFileMsg">
         <source xml:lang="en">File '{0}' is not a SayMore annotation file. It is possibly corrupt.</source>
-        <note>ID: SessionsView.Transcription.BadAnnotationFileMsg</note>
         <target xml:lang="es-ES" state="translated">El archivo '{0}' no es un archivo de anotación de SayMore. Posiblemente está dañado.</target>
+        <note>ID: SessionsView.Transcription.BadAnnotationFileMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.ErrorAccessingMediaFile">
         <source xml:lang="en">There was an error accessing media file to determine the duration: '{0}'</source>
-        <note>ID: SessionsView.Transcription.ErrorAccessingMediaFile</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al intentar cargar el archivo multimedia para determinar la duración: '{0}'.</target>
+        <note>ID: SessionsView.Transcription.ErrorAccessingMediaFile</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.FontDialogProblem">
         <source xml:lang="en">There was some problem with choosing that font. If you just installed it, you might try restarting the program or even your computer.</source>
-        <note>ID: SessionsView.Transcription.FontDialogProblem</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un problema con la selección de esa fuente. Si usted la acaba de instalar, puede intentar reiniciar el programa o incluso la computadora, y luego volver a intentar seleccionar la fuente.</target>
+        <note>ID: SessionsView.Transcription.FontDialogProblem</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.FontsMenu">
         <source xml:lang="en">&amp;Fonts...</source>
-        <note>ID: SessionsView.Transcription.FontsMenu</note>
         <target xml:lang="es-ES" state="translated">&amp;Fuentes...</target>
+        <note>ID: SessionsView.Transcription.FontsMenu</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileDetails">
         <source xml:lang="en">Attempting to generate file:</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileDetails</note>
         <target xml:lang="es-ES" state="translated">Intentando generar el archivo:</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileDetails</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileGenericErrorMsg">
         <source xml:lang="en">There was an error generating the oral annotation file.</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileGenericErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al generar el archivo de anotación oral.</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileGenericErrorMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileMsg">
         <source xml:lang="en">Generating Oral Annotation file...</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileMsg</note>
         <target xml:lang="es-ES" state="translated">Generando el archivo de anotacion oral...</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.GeneratingOralAnnotationFileMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.HelpButton">
         <source xml:lang="en">Help</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.HelpButton</note>
         <target xml:lang="es-ES" state="translated">Ayuda</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.HelpButton</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.HelpButton_ToolTip_">
         <source xml:lang="en">Help</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.HelpButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Ayuda</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.HelpButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.OralAnnotationFilePossiblyTooLarge">
         <source xml:lang="en">The generated oral annotation file may be too large to display or play correctly.</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.OralAnnotationFilePossiblyTooLarge</note>
         <target xml:lang="es-ES" state="translated">El archivo de anotaciones orales generado puede ser demasiado grande para mostrarlo o reproducir correctamente.</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.OralAnnotationFilePossiblyTooLarge</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.OralAnnotationFileProblem">
         <source xml:lang="en">Problem occurred attempting to display generated oral annotation file.</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.OralAnnotationFileProblem</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al intentar presentar el archivo de anotación oral.</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.OralAnnotationFileProblem</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.PlayButton">
         <source xml:lang="en">Play</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.PlayButton</note>
         <target xml:lang="es-ES" state="translated">Reproducir</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.PlayButton</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.PlayButton_ToolTip_">
         <source xml:lang="en">Playback Oral Annotation Audio File</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.PlayButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Reproducir archivo para anotacion oral</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.PlayButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.ProcessingAnnotationFileErrorMsg">
         <source xml:lang="en">There was an error processing a {0} annotation file.</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.ProcessingAnnotationFileErrorMsg</note>
-        <note>The parameter is the annotation type (i.e. careful, translation).</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al procesar un archivo de anotación {0}.</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.ProcessingAnnotationFileErrorMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.ProcessingSourceRecordingErrorMsg">
         <source xml:lang="en">There was an error processing the source recording.</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.ProcessingSourceRecordingErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al procesar la grabación original.</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.ProcessingSourceRecordingErrorMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.RegenerateButton">
         <source xml:lang="en">Regenerate</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.RegenerateButton</note>
         <target xml:lang="es-ES" state="translated">Regenerar</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.RegenerateButton</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.RegenerateButton_ToolTip_">
         <source xml:lang="en">Regenerate Oral Annotation Audio File</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.RegenerateButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Regenerar archivo de anotación oral</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.RegenerateButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.StopButton">
         <source xml:lang="en">Stop</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.StopButton</note>
         <target xml:lang="es-ES" state="translated">Parar</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.StopButton</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.StopButton_ToolTip_">
         <source xml:lang="en">Stop Playback</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.StopButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Parar reproducción</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.StopButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.GeneratedOralAnnotationView.TabText">
         <source xml:lang="en">Generated Audio</source>
-        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.TabText</note>
         <target xml:lang="es-ES" state="translated">Audio generado</target>
+        <note>ID: SessionsView.Transcription.GeneratedOralAnnotationView.TabText</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.OptionsMenu">
         <source xml:lang="en">Options</source>
-        <note>ID: SessionsView.Transcription.OptionsMenu</note>
         <target xml:lang="es-ES" state="translated">Opciones</target>
+        <note>ID: SessionsView.Transcription.OptionsMenu</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.Transcription.ProbablyCannotGetDuration">
+        <source xml:lang="en">It will probably not be possible to determine the media file duration.</source>
+        <target xml:lang="es-ES" state="translated">Probablemente no sea posible determinar la duración del archivo multimedia.</target>
+        <note>ID: SessionsView.Transcription.ProbablyCannotGetDuration</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._buttonConvert">
         <source xml:lang="en">Convert</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._buttonConvert</note>
         <target xml:lang="es-ES" state="translated">Convertir</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._buttonConvert</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelHeading">
         <source xml:lang="en">File Conversion Required</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelHeading</note>
         <target xml:lang="es-ES" state="translated">Conversión de archivo necesario</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelHeading</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelIntroduction.ForAudio">
         <source xml:lang="en">The format of this audio file is '{0}'. In order to annotate, SayMore needs to convert it to WAV PCM, which is a good, standard choice for archiving. During the conversion process, a standard audio file will be created from the source and added to the session's file list. The name of the new audio file will be the same as the source with the suffix "{1}" added to the end. The source file will remain unchanged in the session's file list.</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelIntroduction.ForAudio</note>
         <target xml:lang="es-ES" state="translated">El formato de este archivo de audio es '{0}'. Para anotarlo, SayMore necesita convertirlo a WAV PCM, un formato estándar que es una buena opción para archivo permanente. Durante el proceso de conversión, un nuevo archivo audio será creado y agregado a la lista de archivos de la sesión. El nombre del nuevo archivo de audio será igual a la de la fuente pero con la extensión "{1}". El archivo original no se modificará y permanecerá en la lista de archivos de la sesión.</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelIntroduction.ForAudio</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelIntroduction.ForVideo">
         <source xml:lang="en">In order to annotate, SayMore needs to convert this video to WAV PCM audio. During the conversion process, a standard audio file will be created from the source and added to the session's file list. The name of the new audio file will be the same as the name of the source with the suffix "{0}" added to the end. The source file will remain unchanged in the session's file list.</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelIntroduction.ForVideo</note>
         <target xml:lang="es-ES" state="translated">Para anotar, SayMore necesita convertir este vídeo a audio WAV PCM. Durante el proceso de conversión, un nuevo archivo audio será creado y agregado a la lista de archivos de la sesión. El nombre del nuevo archivo de audio será igual a la de la fuente pero con la extensión "{0}". El archivo original no se modificará y permanecerá en la lista de archivos de la sesión.</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelIntroduction.ForVideo</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelSourceFileName">
         <source xml:lang="en">Name of source media file:</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelSourceFileName</note>
         <target xml:lang="es-ES" state="translated">Nombre del archivo multimedia original:</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelSourceFileName</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelStandardAudioFileName">
         <source xml:lang="en">Name of new, standard audio file:</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelStandardAudioFileName</note>
         <target xml:lang="es-ES" state="translated">Nombre del nuevo archivo de audio estándar:</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab.ConvertToStandardAudio._labelStandardAudioFileName</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab.TabText">
         <source xml:lang="en">Start Annotating</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab.TabText</note>
         <target xml:lang="es-ES" state="translated">Empezar a anotar</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab.TabText</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._buttonGetStarted">
         <source xml:lang="en">Get Started...</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._buttonGetStarted</note>
         <target xml:lang="es-ES" state="translated">Empezar...</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._buttonGetStarted</note>
+      </trans-unit>
+      <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._labelAudacityLabelTier">
+        <source xml:lang="en">Import label text into</source>
+        <target xml:lang="es-ES" state="translated">Importar texto de las etiquetas a la</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._labelAudacityLabelTier</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._labelIntroduction">
         <source xml:lang="en">You can add transcription, translation, careful speech and audio translation to this media file. But first...</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._labelIntroduction</note>
         <target xml:lang="es-ES" state="translated">Puede agregarse audio traducción, traducción escrita, discurso cuidadoso y transcripción a este archivo multimedia. Pero primero...</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._labelIntroduction</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._labelSegmentationMethod">
         <source xml:lang="en">Segmentation Method</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._labelSegmentationMethod</note>
         <target xml:lang="es-ES" state="translated">Método de segmentación</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._labelSegmentationMethod</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._labelSegmentationMethodQuestion">
         <source xml:lang="en">Each annotation will be linked to a single time segment of media. How would you like to identify those segments?</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._labelSegmentationMethodQuestion</note>
         <target xml:lang="es-ES" state="translated">Cada anotación se vinculará a un segmento único de la multimedia original. ¿Cómo le gustaría delimitar aquellos segmentos?</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._labelSegmentationMethodQuestion</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._radioButtonAudacity">
         <source xml:lang="en">Read an Audacity Label file</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonAudacity</note>
         <target xml:lang="es-ES" state="translated">Leer un archivo de Audacity con etiquetas</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonAudacity</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._radioButtonAutoSegmenter">
         <source xml:lang="en">Use auto segmenter</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonAutoSegmenter</note>
         <target xml:lang="es-ES" state="translated">Usar el auto segmentador</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonAutoSegmenter</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._radioButtonCarefulSpeech">
         <source xml:lang="en">Use Careful Speech Tool</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonCarefulSpeech</note>
         <target xml:lang="es-ES" state="translated">Usar el cuadro de diálogo para grabar el habla cuidadosa</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonCarefulSpeech</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._radioButtonElan">
         <source xml:lang="en">Copy an existing ELAN file</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonElan</note>
         <target xml:lang="es-ES" state="translated">Copiar un archivo existente de ELAN</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonElan</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.StartAnnotatingTab._radioButtonManual">
         <source xml:lang="en">Use Manual Segmentation Tool</source>
-        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonManual</note>
         <target xml:lang="es-ES" state="translated">Usar la cuadro de diálogo de segmentación manual</target>
+        <note>ID: SessionsView.Transcription.StartAnnotatingTab._radioButtonManual</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.CarefulSpeechFileDescriptor">
         <source xml:lang="en">Careful Speech File ({0})</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.CarefulSpeechFileDescriptor</note>
         <target xml:lang="es-ES" state="translated">archivo de habla cuidadosa ({0})</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.CarefulSpeechFileDescriptor</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.CommaSeparatedValuesFileDescriptor">
         <source xml:lang="en">Comma Separated Values File ({0})</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.CommaSeparatedValuesFileDescriptor</note>
         <target xml:lang="es-ES" state="translated">archivo de valores separados por comas ({0})</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.CommaSeparatedValuesFileDescriptor</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu">
         <source xml:lang="en">Export</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu</note>
         <target xml:lang="es-ES" state="translated">Exportar</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityFreeTranslation">
         <source xml:lang="en">Audacity Label File (Free Translation)...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityFreeTranslation</note>
         <target xml:lang="es-ES" state="translated">Archivo de etiquetas de Audacity (traducción libre)...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityFreeTranslation</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityFreeTranslationFilenameSuffix">
         <source xml:lang="en">audacity_freeTranslation</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityFreeTranslationFilenameSuffix</note>
-        <note>Probably does not need to be localized</note>
         <target xml:lang="es-ES" state="needs-translation">audacity_freeTranslation</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityFreeTranslationFilenameSuffix</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityTranscription">
         <source xml:lang="en">Audacity Label File (Transcription)...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityTranscription</note>
         <target xml:lang="es-ES" state="translated">Archivo de etiquetas de Audacity (transcripción)...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityTranscription</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityTranscriptionFilenameSuffix">
         <source xml:lang="en">audacity_transcription</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityTranscriptionFilenameSuffix</note>
-        <note>Probably does not need to be localized</note>
         <target xml:lang="es-ES" state="needs-translation">audacity_transcription</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudacityTranscriptionFilenameSuffix</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.AudioExportFileLocked">
         <source xml:lang="en">Audio export failed because the selected output file already exists and is locked.</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudioExportFileLocked</note>
         <target xml:lang="es-ES" state="translated">La exportación de audio falló porque el archivo de salida seleccionado ya existe y está bloqueado.</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.AudioExportFileLocked</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.CarefulSpeachAudioExport">
         <source xml:lang="en">Careful Speech Audio...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.CarefulSpeachAudioExport</note>
         <target xml:lang="es-ES" state="translated">Grabación de habla cuidadosa...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.CarefulSpeachAudioExport</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.ExportElanMenuItem">
         <source xml:lang="en">ELAN File...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.ExportElanMenuItem</note>
         <target xml:lang="es-ES" state="translated">Archivo ELAN...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.ExportElanMenuItem</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.ExportElanMessage">
         <source xml:lang="en">Actually, SayMore already stores this information in ELAN format (.eaf). Simply double click the annotations file to edit it in ELAN.</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.ExportElanMessage</note>
         <target xml:lang="es-ES" state="translated">En realidad, SayMore ya almacena esta información en formato de ELAN (.eaf). Simplemente haga doble clic en el archivo de anotaciones para editarlo en ELAN.</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.ExportElanMessage</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.FLExTextExport">
         <source xml:lang="en">FLEx Interlinear Text...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.FLExTextExport</note>
         <target xml:lang="es-ES" state="translated">FLEx Interlineal...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.FLExTextExport</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.OralTranslationAudioExport">
         <source xml:lang="en">Oral Translation Audio...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.OralTranslationAudioExport</note>
         <target xml:lang="es-ES" state="translated">Grabación de traducción oral...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.OralTranslationAudioExport</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.ToolboxExport">
         <source xml:lang="en">Toolbox File...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.ToolboxExport</note>
         <target xml:lang="es-ES" state="translated">Archivo de Toolbox...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.ToolboxExport</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.commaSeparatedValueExport">
         <source xml:lang="en">Spreadsheet (CSV) File...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.commaSeparatedValueExport</note>
         <target xml:lang="es-ES" state="translated">Archivo de hoja de cálculo (CSV)...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.commaSeparatedValueExport</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.plainTextExport">
         <source xml:lang="en">Plain Text...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.plainTextExport</note>
         <target xml:lang="es-ES" state="translated">Texto...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.plainTextExport</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesFreeTranslationExport.freeTranslationFilenameSuffix">
         <source xml:lang="en">freeTranslation_subtitle</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesFreeTranslationExport.freeTranslationFilenameSuffix</note>
         <target xml:lang="es-ES" state="translated">subtitulo_traduccion</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesFreeTranslationExport.freeTranslationFilenameSuffix</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscription">
         <source xml:lang="en">Subtitles File (Transcription)...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscription</note>
         <target xml:lang="es-ES" state="translated">Archivo de subtítulos (transcripción)...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscription</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscriptionExport.TranscriptionFileDescriptor">
         <source xml:lang="en">SRT Subtitle File ({0})</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscriptionExport.TranscriptionFileDescriptor</note>
         <target xml:lang="es-ES" state="translated">archivo de subtítulos SRT ({0})</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscriptionExport.TranscriptionFileDescriptor</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscriptionExport.transcriptionFilenameSuffix">
         <source xml:lang="en">transcription_subtitle</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscriptionExport.transcriptionFilenameSuffix</note>
         <target xml:lang="es-ES" state="translated">subtitulo_transcripcion</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlesTranscriptionExport.transcriptionFilenameSuffix</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlestFreeTranslation">
         <source xml:lang="en">Subtitles File (Free Translation)...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlestFreeTranslation</note>
         <target xml:lang="es-ES" state="translated">Archivo de subtítulos (traducción libre)...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.ExportMenu.srtSubtitlestFreeTranslation</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotation.OralTranslationFileDescriptor">
         <source xml:lang="en">Oral Translation File ({0})</source>
-        <note>ID: SessionsView.Transcription.TextAnnotation.OralTranslationFileDescriptor</note>
         <target xml:lang="es-ES" state="translated">archivo de traducción oral ({0})</target>
+        <note>ID: SessionsView.Transcription.TextAnnotation.OralTranslationFileDescriptor</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.CarefulSpeechMenuText">
         <source xml:lang="en">&amp;Careful Speech...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.CarefulSpeechMenuText</note>
         <target xml:lang="es-ES" state="translated">Habla &amp;Cuidadosa...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.CarefulSpeechMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.CopyColumnTextToClipboardMenuText">
         <source xml:lang="en">Copy {0} to clipboard</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.CopyColumnTextToClipboardMenuText</note>
-        <note>Parameter is column (i.e. tier) name</note>
         <target xml:lang="es-ES" state="translated">Copiar {0} al portapapeles</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.CopyColumnTextToClipboardMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.Caption">
         <source xml:lang="en">Exporting to FLEx Interlinear</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.Caption</note>
         <target xml:lang="es-ES" state="translated">Exportación a FLEx interlineal</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.Caption</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.FinsihedMsg">
         <source xml:lang="en">Finished Exporting</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.FinsihedMsg</note>
         <target xml:lang="es-ES" state="translated">Exportación finalizado</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.FinsihedMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.ProgressMsg">
         <source xml:lang="en">Exporting...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.ProgressMsg</note>
         <target xml:lang="es-ES" state="translated">Exportando...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ExportingToFLExInterlinear.ProgressDlg.ProgressMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.Both">
         <source xml:lang="en">Playback Both Recordings</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.Both</note>
         <target xml:lang="es-ES" state="translated">Reproducir ambas grabaciones</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.Both</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.OralTranslation">
         <source xml:lang="en">Playback Oral Translation Recording</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.OralTranslation</note>
         <target xml:lang="es-ES" state="translated">Reproducir grabación de traducción oral</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.OralTranslation</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.Source">
         <source xml:lang="en">Playback Source Recording</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.Source</note>
         <target xml:lang="es-ES" state="translated">Reproducir grabación original</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.FreeTranslationColumnPlaybackMenuOptions.Source</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.HelpButton">
         <source xml:lang="en">Help</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.HelpButton</note>
         <target xml:lang="es-ES" state="translated">Ayuda</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.HelpButton</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.HelpButton_ToolTip_">
         <source xml:lang="en">Help</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.HelpButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Ayuda</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.HelpButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.IgnoredMenuText">
         <source xml:lang="en">&amp;Ignored</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.IgnoredMenuText</note>
         <target xml:lang="es-ES" state="translated">&amp;Ignorado</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.IgnoredMenuText</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.IgnoredSegmentIndicator">
         <source xml:lang="en">Ignored</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.IgnoredSegmentIndicator</note>
         <target xml:lang="es-ES" state="translated">Ignorado</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.IgnoredSegmentIndicator</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.LoadingAnnotationFileErrorMsg">
         <source xml:lang="en">There was an error loading the annotation file '{0}'.</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.LoadingAnnotationFileErrorMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al intentar cargar el archivo de anotación '{0}'.</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.LoadingAnnotationFileErrorMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.NoTranscriptionAnnotationsFoundMsg">
         <source xml:lang="en">There are no transcription annotations found in\n'{0}'</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.NoTranscriptionAnnotationsFoundMsg</note>
-        <note>Parameter is file name.</note>
         <target xml:lang="es-ES" state="translated">No se encuentran anotaciones de transcripción en\n'{0}'</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.NoTranscriptionAnnotationsFoundMsg</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.OralTranslationMenu">
         <source xml:lang="en">&amp;Oral Translation...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.OralTranslationMenu</note>
         <target xml:lang="es-ES" state="translated">Traducción &amp;Oral...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.OralTranslationMenu</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.RecordButton">
         <source xml:lang="en">Oral Annotations Tools</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.RecordButton</note>
         <target xml:lang="es-ES" state="translated">Herramientas de anotacion oral</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.RecordButton</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.RecordButton_ToolTip_">
         <source xml:lang="en">Record Oral Annotations</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.RecordButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Grabar anotaciones orales</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.RecordButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.ResegmentButton">
         <source xml:lang="en">Segment...</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ResegmentButton</note>
         <target xml:lang="es-ES" state="translated">Segmentar...</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ResegmentButton</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.ResegmentButton_ToolTip_">
         <source xml:lang="en">Add, remove or move segment boundaries</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ResegmentButton_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Añadir, eliminar o mover divisiones de segmentos</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.ResegmentButton_ToolTip_</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.SegmentTooltip">
         <source xml:lang="en">Segment range: {0}\nPress {1} to Play/Pause</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.SegmentTooltip</note>
-        <note>First parameter is time range of the segment (e.g., 00.0-02.1); Second parameter is "F2"</note>
         <target xml:lang="es-ES" state="translated">Gama del segmento: {0}\nPrensa {1} para reproducir/pausar</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.SegmentTooltip</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.TabText">
         <source xml:lang="en">Annotations</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.TabText</note>
         <target xml:lang="es-ES" state="translated">Anotaciones</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.TabText</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.Both">
         <source xml:lang="en">Playback Both Recordings</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.Both</note>
         <target xml:lang="es-ES" state="translated">Reproducir ambas grabaciones</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.Both</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.CarefulSpeech">
         <source xml:lang="en">Playback Careful Speech Recording</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.CarefulSpeech</note>
         <target xml:lang="es-ES" state="translated">Reproducir grabación de habla cuidadosa</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.CarefulSpeech</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.Source">
         <source xml:lang="en">Playback Source Recording</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.Source</note>
         <target xml:lang="es-ES" state="translated">Reproducir grabación original</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor.TranscriptionColumnPlaybackMenuOptions.Source</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TextAnnotationEditor._comboPlaybackSpeed_ToolTip_">
         <source xml:lang="en">Playback speed</source>
-        <note>ID: SessionsView.Transcription.TextAnnotationEditor._comboPlaybackSpeed_ToolTip_</note>
         <target xml:lang="es-ES" state="translated">Velocidad de reproducción</target>
+        <note>ID: SessionsView.Transcription.TextAnnotationEditor._comboPlaybackSpeed_ToolTip_</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TierDisplayNames.FreeTranslation">
         <source xml:lang="en">Free Translation</source>
-        <note>ID: SessionsView.Transcription.TierDisplayNames.FreeTranslation</note>
         <target xml:lang="es-ES" state="translated">Traducción libre</target>
+        <note>ID: SessionsView.Transcription.TierDisplayNames.FreeTranslation</note>
       </trans-unit>
       <trans-unit id="SessionsView.Transcription.TierDisplayNames.Transcription">
         <source xml:lang="en">Transcription</source>
-        <note>ID: SessionsView.Transcription.TierDisplayNames.Transcription</note>
         <target xml:lang="es-ES" state="translated">Transcripción</target>
+        <note>ID: SessionsView.Transcription.TierDisplayNames.Transcription</note>
       </trans-unit>
       <trans-unit id="SessionsView.ViewTabText">
         <source xml:lang="en">Sessions</source>
-        <note>ID: SessionsView.ViewTabText</note>
         <target xml:lang="es-ES" state="translated">Sesiones</target>
+        <note>ID: SessionsView.ViewTabText</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.ConversionOutputFileAlreadyErrorMsg">
         <source xml:lang="en">Sorry, the file '{0}' already exists.</source>
-        <note>ID: SoundFileUtils.ConversionOutputFileAlreadyErrorMsg</note>
         <target xml:lang="es-ES" state="translated">El archivo '{0}' ya existe.</target>
+        <note>ID: SoundFileUtils.ConversionOutputFileAlreadyErrorMsg</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.ConvertToStandardWavPcmAudioErrorMsg">
         <source xml:lang="en">There was an error trying to create a standard audio file from:\n\n{0}</source>
-        <note>ID: SoundFileUtils.ConvertToStandardWavPcmAudioErrorMsg</note>
-        <note>Parameter is the file name of the media file used as the basis for the attempted conversion.</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al intentar crear un archivo de audio estándar usando este archivo como fuente:\n\n{0}</target>
+        <note>ID: SoundFileUtils.ConvertToStandardWavPcmAudioErrorMsg</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.ConvertToStandardWavPcmAudioMsg">
         <source xml:lang="en">Converting...</source>
-        <note>ID: SoundFileUtils.ConvertToStandardWavPcmAudioMsg</note>
         <target xml:lang="es-ES" state="translated">Convertiendo...</target>
+        <note>ID: SoundFileUtils.ConvertToStandardWavPcmAudioMsg</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.ErrorFindingPcmAudioDriverMsg">
         <source xml:lang="en">There was an error trying to find a PCM audio driver on this computer. Ensure that you have a PCM sound driver installed.</source>
-        <note>ID: SoundFileUtils.ErrorFindingPcmAudioDriverMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al intentar encontrar un controlador de audio PCM en este equipo. Asegúrese de que tiene un controlador de sonido PCM instalado.</target>
+        <note>ID: SoundFileUtils.ErrorFindingPcmAudioDriverMsg</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.ErrorFindingPcmConversionCapabilitiesMsg">
         <source xml:lang="en">There was an error trying to find PCM audio conversion capabilities on this computer. Ensure that you have a PCM sound driver installed.</source>
-        <note>ID: SoundFileUtils.ErrorFindingPcmConversionCapabilitiesMsg</note>
         <target xml:lang="es-ES" state="translated">Ocurrió un error al intentar encontrar capacidades de conversión audio PCM en este equipo. Asegúrese de que tiene un controlador de sonido PCM instalado.</target>
+        <note>ID: SoundFileUtils.ErrorFindingPcmConversionCapabilitiesMsg</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.ExtractingAudioError">
         <source xml:lang="en">There was an error extracting audio from the media file '{0}'\n\n{1}</source>
-        <note>ID: SoundFileUtils.ExtractingAudioError</note>
-        <note>Second parameter is the error message.</note>
         <target xml:lang="es-ES" state="translated">Hubo un error al extraer audio de archivo multimedia '{0}'\n\n{1}</target>
+        <note>ID: SoundFileUtils.ExtractingAudioError</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.FileMayNotBeValidAudioError">
         <source xml:lang="en">No audio track could be found in the specified file. Verify that the file is a valid audio file.</source>
-        <note>ID: SoundFileUtils.FileMayNotBeValidAudioError</note>
         <target xml:lang="es-ES" state="translated">No se puede encontrar ninguna pista de audio en el archivo especificado. Compruebe que el archivo es un archivo válido de audio.</target>
+        <note>ID: SoundFileUtils.FileMayNotBeValidAudioError</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.MediaFileDoesNotExistErrorMsg">
         <source xml:lang="en">Media file does not exist.</source>
-        <note>ID: SoundFileUtils.MediaFileDoesNotExistErrorMsg</note>
         <target xml:lang="es-ES" state="translated">No existe el archivo multimedia.</target>
+        <note>ID: SoundFileUtils.MediaFileDoesNotExistErrorMsg</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.PossibleConversionErrorMsg">
         <source xml:lang="en">Conversion completed, but with possible error(s). If the converted file does not appear to be usable, delete it and check the validity of the source file. After checking the source file and the conversion output details, if you believe this is a problem with SayMore, please include a copy of the source file with your error report.</source>
-        <note>ID: SoundFileUtils.PossibleConversionErrorMsg</note>
         <target xml:lang="es-ES" state="translated">La conversión se realizó, pero con posibles errores. Si el archivo convertido no funciona, borrelo y compruebe la validez del archivo original. Después de comprobar el archivo original y los detalles de salida de la conversión, si usted cree que hay un problema con SayMore, al reportar el error por favor incluya también una copia del archivo original.</target>
+        <note>ID: SoundFileUtils.PossibleConversionErrorMsg</note>
       </trans-unit>
       <trans-unit id="SoundFileUtils.UnexpectedEndOfStream">
         <source xml:lang="en">Fewer values than requested were found in\n{0}.\nFile may be corrupt. Requested values: {1}. Actual values returned: {2}</source>
-        <note>ID: SoundFileUtils.UnexpectedEndOfStream</note>
-        <note>Param 0: Name of the file used as the source of the data stream;Param 1: Number of values requested;Param 2: Number of values read</note>
         <target xml:lang="es-ES" state="translated">Se encontraron menos valores que los que se solicitaba en\n{0}.\nEl archivo puede estar dañado. Valores solicitados: {1}. Valores reales devueltos: {2}</target>
+        <note>ID: SoundFileUtils.UnexpectedEndOfStream</note>
       </trans-unit>
     </body>
   </file>

--- a/DistFiles/aboutBox.htm
+++ b/DistFiles/aboutBox.htm
@@ -6,7 +6,7 @@
     <link rel="stylesheet" type="text/css" href="aboutBox.css" />
 </head>
 <body>
-    <h1 style="margin-top:8px">Copyright © 2011-2022 <a href="https://www.sil.org/">SIL International</a></h1>
+    <h1 style="margin-top:8px">Copyright © 2011-2023 <a href="https://www.sil.org/">SIL International</a></h1>
 
     <h1>License</h1>
     <p>Open source (<a href="https://sil.mit-license.org/">MIT</a>).</p>

--- a/DistFiles/releaseNotes.md
+++ b/DistFiles/releaseNotes.md
@@ -1,3 +1,6 @@
+## Version 3.4
+Added option to import Audacity labels into free translation (instead of the transcription tier)
+
 ## Version 3.3
 Localization files are now stored in the XLIFF format (v. 1.2). If you have custom localizations saved in TMX format, please contact sil.saymore@gmail.com for help.
 

--- a/build/SayMore.proj
+++ b/build/SayMore.proj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<RootDir Condition="'$(teamcity_version)' == ''">$(MSBuildProjectDirectory)\..</RootDir>
 	<RootDir Condition="'$(teamcity_version)' != ''">$(teamcity_build_checkoutDir)</RootDir>
-	<BUILD_NUMBER Condition="'$(BUILD_NUMBER)'==''">3.3.0</BUILD_NUMBER>
+	<BUILD_NUMBER Condition="'$(BUILD_NUMBER)'==''">3.4.0</BUILD_NUMBER>
 	<BuildTasksDll>$(RootDir)/packages/SIL.BuildTasks.2.5.0/tools/SIL.BuildTasks.dll</BuildTasksDll>
 	<Configuration>Release</Configuration>
 	<RestartBuild Condition="!Exists('$(BuildTasksDll)')">true</RestartBuild>
@@ -26,7 +26,7 @@
 	<Message Text="BuildCounter: $(BuildCounter)" Importance="high"/>
 
 	<!-- Note, after some thought, we've decided this is the best place to keep the version number (not on TeamCity, not in the assemblies).     -->
-	<CreateProperty Value="3.3.$(BuildCounter)">
+	<CreateProperty Value="3.4.$(BuildCounter)">
 	  <Output PropertyName="Version" TaskParameter="Value"/>
 	</CreateProperty>
 

--- a/src/SayMore/Properties/AssemblyInfo.cs
+++ b/src/SayMore/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL International")]
 [assembly: AssemblyProduct("SayMore")]
-[assembly: AssemblyCopyright("Copyright © 2011-2022 SIL International")]
+[assembly: AssemblyCopyright("Copyright © 2011-2023 SIL International")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/SayMore/SayMore.csproj
+++ b/src/SayMore/SayMore.csproj
@@ -374,6 +374,7 @@
     <Compile Include="Transcription\Model\TierCollection.cs" />
     <Compile Include="Transcription\Model\TimeRange.cs" />
     <Compile Include="Transcription\Model\TimeTier.cs" />
+    <Compile Include="Transcription\UI\CommonUIStrings.cs" />
     <Compile Include="Transcription\UI\SegmentingAndRecording\OralAnnotationRecorder.cs" />
     <Compile Include="Transcription\UI\StandardAudioButtons.cs" />
     <Compile Include="Transcription\Model\AudacityLabelHelper.cs" />

--- a/src/SayMore/Transcription/Model/Exporters/PlainTextTranscriptionExporter.cs
+++ b/src/SayMore/Transcription/Model/Exporters/PlainTextTranscriptionExporter.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using L10NSharp;
+using SayMore.Transcription.UI;
 
 namespace SayMore.Transcription.Model.Exporters
 {
@@ -12,7 +13,7 @@ namespace SayMore.Transcription.Model.Exporters
 		{
 			using (var stream = File.CreateText(outputFilePath))
 			{
-				stream.WriteLine("-- " + LocalizationManager.GetString("SessionsView.Transcription.TierDisplayNames.Transcription", "Transcription") + " --");
+				stream.WriteLine("-- " + CommonUIStrings.TranscriptionTierDisplayName + " --");
 				stream.WriteLine();
 				foreach (var segment in tiers.GetTranscriptionTier().Segments)
 				{
@@ -21,7 +22,7 @@ namespace SayMore.Transcription.Model.Exporters
 
 				stream.WriteLine();
 				stream.WriteLine();
-				stream.WriteLine("-- " + LocalizationManager.GetString("SessionsView.Transcription.TierDisplayNames.FreeTranslation", "Free Translation") + " --");
+				stream.WriteLine("-- " + CommonUIStrings.TranslationTierDisplayName + " --");
 				stream.WriteLine();
 				foreach (var segment in tiers.GetFreeTranslationTier().Segments)
 				{

--- a/src/SayMore/Transcription/UI/CommonUIStrings.cs
+++ b/src/SayMore/Transcription/UI/CommonUIStrings.cs
@@ -1,0 +1,16 @@
+﻿using L10NSharp;
+
+namespace SayMore.Transcription.UI
+{
+    internal static class CommonUIStrings
+    {
+        internal static string TranscriptionTierDisplayName =>
+            LocalizationManager.GetString("SessionsView.Transcription.TierDisplayNames.Transcription", "Transcription");
+
+        public static string TranslationTierDisplayName =>
+            LocalizationManager.GetString("SessionsView.Transcription.TierDisplayNames.FreeTranslation", "Free Translation");
+
+        public static string StartAnnotatingTabText => LocalizationManager.GetString(
+            "SessionsView.Transcription.StartAnnotatingTab.TabText", "Start Annotating");
+    }
+}

--- a/src/SayMore/Transcription/UI/ComponentEditors/ConvertToStandardAudioEditor.cs
+++ b/src/SayMore/Transcription/UI/ComponentEditors/ConvertToStandardAudioEditor.cs
@@ -117,8 +117,7 @@ namespace SayMore.Transcription.UI
 		{
 			if (lm == null || lm.Id == ApplicationContainer.kSayMoreLocalizationId)
 			{
-				TabText = LocalizationManager.GetString(
-					"SessionsView.Transcription.StartAnnotatingTab.TabText", "Start Annotating");
+				TabText = CommonUIStrings.StartAnnotatingTabText;
 			}
 
 			base.HandleStringsLocalized(lm);

--- a/src/SayMore/Transcription/UI/ComponentEditors/StartAnnotatingEditor.Designer.cs
+++ b/src/SayMore/Transcription/UI/ComponentEditors/StartAnnotatingEditor.Designer.cs
@@ -47,7 +47,7 @@ namespace SayMore.Transcription.UI
 			this._radioButtonAutoSegmenter = new System.Windows.Forms.RadioButton();
 			this._buttonAutoSegmenterHelp = new System.Windows.Forms.Button();
 			this._cboAudacityLabelTier = new System.Windows.Forms.ComboBox();
-			this._lblAudacityLabelTier = new System.Windows.Forms.Label();
+			this._labelAudacityLabelTier = new System.Windows.Forms.Label();
 			this.locExtender = new L10NSharp.UI.L10NSharpExtender(this.components);
 			this._tableLayoutGetStarted.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.locExtender)).BeginInit();
@@ -78,7 +78,7 @@ namespace SayMore.Transcription.UI
 			this._tableLayoutGetStarted.Controls.Add(this._radioButtonAutoSegmenter, 2, 5);
 			this._tableLayoutGetStarted.Controls.Add(this._buttonAutoSegmenterHelp, 3, 5);
 			this._tableLayoutGetStarted.Controls.Add(this._cboAudacityLabelTier, 3, 4);
-			this._tableLayoutGetStarted.Controls.Add(this._lblAudacityLabelTier, 2, 4);
+			this._tableLayoutGetStarted.Controls.Add(this._labelAudacityLabelTier, 2, 4);
 			this._tableLayoutGetStarted.Dock = System.Windows.Forms.DockStyle.Top;
 			this._tableLayoutGetStarted.Location = new System.Drawing.Point(12, 6);
 			this._tableLayoutGetStarted.Name = "_tableLayoutGetStarted";
@@ -369,20 +369,19 @@ namespace SayMore.Transcription.UI
 			this._cboAudacityLabelTier.Size = new System.Drawing.Size(100, 21);
 			this._cboAudacityLabelTier.TabIndex = 14;
 			// 
-			// _lblAudacityLabelTier
+			// _labelAudacityLabelTier
 			// 
-			this._lblAudacityLabelTier.Anchor = System.Windows.Forms.AnchorStyles.Right;
-			this._lblAudacityLabelTier.AutoSize = true;
-			this._lblAudacityLabelTier.Enabled = false;
-			this.locExtender.SetLocalizableToolTip(this._lblAudacityLabelTier, null);
-			this.locExtender.SetLocalizationComment(this._lblAudacityLabelTier, null);
-			this.locExtender.SetLocalizationPriority(this._lblAudacityLabelTier, L10NSharp.LocalizationPriority.NotLocalizable);
-			this.locExtender.SetLocalizingId(this._lblAudacityLabelTier, "StartAnnotatingEditor._lblAudacityLabelTier");
-			this._lblAudacityLabelTier.Location = new System.Drawing.Point(309, 139);
-			this._lblAudacityLabelTier.Name = "_lblAudacityLabelTier";
-			this._lblAudacityLabelTier.Size = new System.Drawing.Size(101, 13);
-			this._lblAudacityLabelTier.TabIndex = 15;
-			this._lblAudacityLabelTier.Text = "Import label text into";
+			this._labelAudacityLabelTier.Anchor = System.Windows.Forms.AnchorStyles.Right;
+			this._labelAudacityLabelTier.AutoSize = true;
+			this._labelAudacityLabelTier.Enabled = false;
+			this.locExtender.SetLocalizableToolTip(this._labelAudacityLabelTier, null);
+			this.locExtender.SetLocalizationComment(this._labelAudacityLabelTier, null);
+			this.locExtender.SetLocalizingId(this._labelAudacityLabelTier, "SessionsView.Transcription.StartAnnotatingTab._labelAudacityLabelTier");
+			this._labelAudacityLabelTier.Location = new System.Drawing.Point(309, 139);
+			this._labelAudacityLabelTier.Name = "_labelAudacityLabelTier";
+			this._labelAudacityLabelTier.Size = new System.Drawing.Size(101, 13);
+			this._labelAudacityLabelTier.TabIndex = 15;
+			this._labelAudacityLabelTier.Text = "Import label text into";
 			// 
 			// locExtender
 			// 
@@ -428,6 +427,6 @@ namespace SayMore.Transcription.UI
 		private Button _buttonCarefulSpeechToolHelp;
 		private Button _buttonManualSegmentationHelp;
 		private ComboBox _cboAudacityLabelTier;
-		private Label _lblAudacityLabelTier;
+		private Label _labelAudacityLabelTier;
 	}
 }

--- a/src/SayMore/Transcription/UI/ComponentEditors/StartAnnotatingEditor.Designer.cs
+++ b/src/SayMore/Transcription/UI/ComponentEditors/StartAnnotatingEditor.Designer.cs
@@ -43,9 +43,11 @@ namespace SayMore.Transcription.UI
 			this._buttonManualSegmentationHelp = new System.Windows.Forms.Button();
 			this._buttonGetStarted = new System.Windows.Forms.Button();
 			this._buttonAudacityHelp = new System.Windows.Forms.Button();
-			this._buttonAutoSegmenterHelp = new System.Windows.Forms.Button();
 			this._radioButtonAudacity = new System.Windows.Forms.RadioButton();
 			this._radioButtonAutoSegmenter = new System.Windows.Forms.RadioButton();
+			this._buttonAutoSegmenterHelp = new System.Windows.Forms.Button();
+			this._cboAudacityLabelTier = new System.Windows.Forms.ComboBox();
+			this._lblAudacityLabelTier = new System.Windows.Forms.Label();
 			this.locExtender = new L10NSharp.UI.L10NSharpExtender(this.components);
 			this._tableLayoutGetStarted.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.locExtender)).BeginInit();
@@ -72,9 +74,11 @@ namespace SayMore.Transcription.UI
 			this._tableLayoutGetStarted.Controls.Add(this._buttonManualSegmentationHelp, 1, 3);
 			this._tableLayoutGetStarted.Controls.Add(this._buttonGetStarted, 0, 8);
 			this._tableLayoutGetStarted.Controls.Add(this._buttonAudacityHelp, 3, 3);
-			this._tableLayoutGetStarted.Controls.Add(this._buttonAutoSegmenterHelp, 3, 4);
 			this._tableLayoutGetStarted.Controls.Add(this._radioButtonAudacity, 2, 3);
-			this._tableLayoutGetStarted.Controls.Add(this._radioButtonAutoSegmenter, 2, 4);
+			this._tableLayoutGetStarted.Controls.Add(this._radioButtonAutoSegmenter, 2, 5);
+			this._tableLayoutGetStarted.Controls.Add(this._buttonAutoSegmenterHelp, 3, 5);
+			this._tableLayoutGetStarted.Controls.Add(this._cboAudacityLabelTier, 3, 4);
+			this._tableLayoutGetStarted.Controls.Add(this._lblAudacityLabelTier, 2, 4);
 			this._tableLayoutGetStarted.Dock = System.Windows.Forms.DockStyle.Top;
 			this._tableLayoutGetStarted.Location = new System.Drawing.Point(12, 6);
 			this._tableLayoutGetStarted.Name = "_tableLayoutGetStarted";
@@ -289,12 +293,45 @@ namespace SayMore.Transcription.UI
 			this.locExtender.SetLocalizationComment(this._buttonAudacityHelp, null);
 			this.locExtender.SetLocalizationPriority(this._buttonAudacityHelp, L10NSharp.LocalizationPriority.NotLocalizable);
 			this.locExtender.SetLocalizingId(this._buttonAudacityHelp, "SessionsView.Transcription.StartAnnotatingTab.AudacityHelpButtonText");
-			this._buttonAudacityHelp.Location = new System.Drawing.Point(449, 107);
+			this._buttonAudacityHelp.Location = new System.Drawing.Point(416, 107);
 			this._buttonAudacityHelp.Name = "_buttonAudacityHelp";
 			this._buttonAudacityHelp.Size = new System.Drawing.Size(22, 22);
 			this._buttonAudacityHelp.TabIndex = 10;
 			this._buttonAudacityHelp.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
 			this._buttonAudacityHelp.UseVisualStyleBackColor = false;
+			// 
+			// _radioButtonAudacity
+			// 
+			this._radioButtonAudacity.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+			this._radioButtonAudacity.AutoSize = true;
+			this.locExtender.SetLocalizableToolTip(this._radioButtonAudacity, null);
+			this.locExtender.SetLocalizationComment(this._radioButtonAudacity, null);
+			this.locExtender.SetLocalizingId(this._radioButtonAudacity, "SessionsView.Transcription.StartAnnotatingTab._radioButtonAudacity");
+			this._radioButtonAudacity.Location = new System.Drawing.Point(255, 109);
+			this._radioButtonAudacity.Margin = new System.Windows.Forms.Padding(25, 3, 3, 3);
+			this._radioButtonAudacity.Name = "_radioButtonAudacity";
+			this._radioButtonAudacity.Size = new System.Drawing.Size(155, 17);
+			this._radioButtonAudacity.TabIndex = 9;
+			this._radioButtonAudacity.TabStop = true;
+			this._radioButtonAudacity.Text = "Read an Audacity Label file";
+			this._radioButtonAudacity.UseVisualStyleBackColor = true;
+			this._radioButtonAudacity.CheckedChanged += new System.EventHandler(this._radioButtonAudacity_CheckedChanged);
+			// 
+			// _radioButtonAutoSegmenter
+			// 
+			this._radioButtonAutoSegmenter.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+			this._radioButtonAutoSegmenter.AutoSize = true;
+			this.locExtender.SetLocalizableToolTip(this._radioButtonAutoSegmenter, null);
+			this.locExtender.SetLocalizationComment(this._radioButtonAutoSegmenter, null);
+			this.locExtender.SetLocalizingId(this._radioButtonAutoSegmenter, "SessionsView.Transcription.StartAnnotatingTab._radioButtonAutoSegmenter");
+			this._radioButtonAutoSegmenter.Location = new System.Drawing.Point(255, 165);
+			this._radioButtonAutoSegmenter.Margin = new System.Windows.Forms.Padding(25, 3, 3, 3);
+			this._radioButtonAutoSegmenter.Name = "_radioButtonAutoSegmenter";
+			this._radioButtonAutoSegmenter.Size = new System.Drawing.Size(155, 17);
+			this._radioButtonAutoSegmenter.TabIndex = 11;
+			this._radioButtonAutoSegmenter.TabStop = true;
+			this._radioButtonAutoSegmenter.Text = "Use auto segmenter";
+			this._radioButtonAutoSegmenter.UseVisualStyleBackColor = true;
 			// 
 			// _buttonAutoSegmenterHelp
 			// 
@@ -312,47 +349,45 @@ namespace SayMore.Transcription.UI
 			this.locExtender.SetLocalizationComment(this._buttonAutoSegmenterHelp, null);
 			this.locExtender.SetLocalizationPriority(this._buttonAutoSegmenterHelp, L10NSharp.LocalizationPriority.NotLocalizable);
 			this.locExtender.SetLocalizingId(this._buttonAutoSegmenterHelp, "SessionsView.Transcription.StartAnnotatingTab.ELANFileHelpButtonText");
-			this._buttonAutoSegmenterHelp.Location = new System.Drawing.Point(449, 135);
+			this._buttonAutoSegmenterHelp.Location = new System.Drawing.Point(416, 163);
 			this._buttonAutoSegmenterHelp.Name = "_buttonAutoSegmenterHelp";
 			this._buttonAutoSegmenterHelp.Size = new System.Drawing.Size(22, 22);
 			this._buttonAutoSegmenterHelp.TabIndex = 13;
 			this._buttonAutoSegmenterHelp.UseVisualStyleBackColor = false;
 			// 
-			// _radioButtonAudacity
+			// _cboAudacityLabelTier
 			// 
-			this._radioButtonAudacity.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-			this._radioButtonAudacity.AutoSize = true;
-			this.locExtender.SetLocalizableToolTip(this._radioButtonAudacity, null);
-			this.locExtender.SetLocalizationComment(this._radioButtonAudacity, null);
-			this.locExtender.SetLocalizingId(this._radioButtonAudacity, "SessionsView.Transcription.StartAnnotatingTab._radioButtonAudacity");
-			this._radioButtonAudacity.Location = new System.Drawing.Point(255, 109);
-			this._radioButtonAudacity.Margin = new System.Windows.Forms.Padding(25, 3, 3, 3);
-			this._radioButtonAudacity.Name = "_radioButtonAudacity";
-			this._radioButtonAudacity.Size = new System.Drawing.Size(188, 17);
-			this._radioButtonAudacity.TabIndex = 9;
-			this._radioButtonAudacity.TabStop = true;
-			this._radioButtonAudacity.Text = "Read an Audacity Label file";
-			this._radioButtonAudacity.UseVisualStyleBackColor = true;
+			this._cboAudacityLabelTier.Enabled = false;
+			this._cboAudacityLabelTier.FormattingEnabled = true;
+			this.locExtender.SetLocalizableToolTip(this._cboAudacityLabelTier, null);
+			this.locExtender.SetLocalizationComment(this._cboAudacityLabelTier, null);
+			this.locExtender.SetLocalizationPriority(this._cboAudacityLabelTier, L10NSharp.LocalizationPriority.NotLocalizable);
+			this.locExtender.SetLocalizingId(this._cboAudacityLabelTier, "StartAnnotatingEditor._cboAudacityLabelTier");
+			this._cboAudacityLabelTier.Location = new System.Drawing.Point(416, 135);
+			this._cboAudacityLabelTier.MinimumSize = new System.Drawing.Size(100, 0);
+			this._cboAudacityLabelTier.Name = "_cboAudacityLabelTier";
+			this._cboAudacityLabelTier.Size = new System.Drawing.Size(100, 21);
+			this._cboAudacityLabelTier.TabIndex = 14;
 			// 
-			// _radioButtonAutoSegmenter
+			// _lblAudacityLabelTier
 			// 
-			this._radioButtonAutoSegmenter.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-			this._radioButtonAutoSegmenter.AutoSize = true;
-			this.locExtender.SetLocalizableToolTip(this._radioButtonAutoSegmenter, null);
-			this.locExtender.SetLocalizationComment(this._radioButtonAutoSegmenter, null);
-			this.locExtender.SetLocalizingId(this._radioButtonAutoSegmenter, "SessionsView.Transcription.StartAnnotatingTab._radioButtonAutoSegmenter");
-			this._radioButtonAutoSegmenter.Location = new System.Drawing.Point(255, 137);
-			this._radioButtonAutoSegmenter.Margin = new System.Windows.Forms.Padding(25, 3, 3, 3);
-			this._radioButtonAutoSegmenter.Name = "_radioButtonAutoSegmenter";
-			this._radioButtonAutoSegmenter.Size = new System.Drawing.Size(188, 17);
-			this._radioButtonAutoSegmenter.TabIndex = 11;
-			this._radioButtonAutoSegmenter.TabStop = true;
-			this._radioButtonAutoSegmenter.Text = "Use auto segmenter";
-			this._radioButtonAutoSegmenter.UseVisualStyleBackColor = true;
+			this._lblAudacityLabelTier.Anchor = System.Windows.Forms.AnchorStyles.Right;
+			this._lblAudacityLabelTier.AutoSize = true;
+			this._lblAudacityLabelTier.Enabled = false;
+			this.locExtender.SetLocalizableToolTip(this._lblAudacityLabelTier, null);
+			this.locExtender.SetLocalizationComment(this._lblAudacityLabelTier, null);
+			this.locExtender.SetLocalizationPriority(this._lblAudacityLabelTier, L10NSharp.LocalizationPriority.NotLocalizable);
+			this.locExtender.SetLocalizingId(this._lblAudacityLabelTier, "StartAnnotatingEditor._lblAudacityLabelTier");
+			this._lblAudacityLabelTier.Location = new System.Drawing.Point(309, 139);
+			this._lblAudacityLabelTier.Name = "_lblAudacityLabelTier";
+			this._lblAudacityLabelTier.Size = new System.Drawing.Size(101, 13);
+			this._lblAudacityLabelTier.TabIndex = 15;
+			this._lblAudacityLabelTier.Text = "Import label text into";
 			// 
 			// locExtender
 			// 
 			this.locExtender.LocalizationManagerId = "SayMore";
+			this.locExtender.PrefixForNewItems = null;
 			// 
 			// StartAnnotatingEditor
 			// 
@@ -392,7 +427,7 @@ namespace SayMore.Transcription.UI
 		private Button _buttonAutoSegmenterHelp;
 		private Button _buttonCarefulSpeechToolHelp;
 		private Button _buttonManualSegmentationHelp;
-
-
+		private ComboBox _cboAudacityLabelTier;
+		private Label _lblAudacityLabelTier;
 	}
 }

--- a/src/SayMore/Transcription/UI/ComponentEditors/StartAnnotatingEditor.cs
+++ b/src/SayMore/Transcription/UI/ComponentEditors/StartAnnotatingEditor.cs
@@ -45,12 +45,14 @@ namespace SayMore.Transcription.UI
 				case 3: _radioButtonAudacity.Checked = true; break;
 				case 4: _radioButtonAutoSegmenter.Checked = true; break;
 			}
-		}
+        }
 
 		/// ------------------------------------------------------------------------------------
 		protected override void OnLoad(EventArgs e)
 		{
 			base.OnLoad(e);
+
+			PopulateAudacityLabelTierItems();
 
 			_labelSegmentationMethod.Font = FontHelper.MakeFont(Program.DialogFont, 10, FontStyle.Bold);
 			_labelIntroduction.Font = Program.DialogFont;
@@ -79,14 +81,31 @@ namespace SayMore.Transcription.UI
 		{
 			if (lm == null || lm.Id == ApplicationContainer.kSayMoreLocalizationId)
 			{
-				TabText = LocalizationManager.GetString(
-					"SessionsView.Transcription.StartAnnotatingTab.TabText", "Start Annotating");
-			}
+				TabText = CommonUIStrings.StartAnnotatingTabText;
+
+                if (_cboAudacityLabelTier != null)
+                {
+                    var selectedIndex = _cboAudacityLabelTier.SelectedIndex;
+                    _cboAudacityLabelTier.Items.Clear();
+                    PopulateAudacityLabelTierItems();
+                    _cboAudacityLabelTier.SelectedIndex = selectedIndex >= 0 ? selectedIndex : 0;
+                }
+            }
 
 			base.HandleStringsLocalized(lm);
 		}
 
-		/// ------------------------------------------------------------------------------------
+        private void PopulateAudacityLabelTierItems()
+        {
+            _cboAudacityLabelTier.Items.AddRange(new [] {
+                CommonUIStrings.TranscriptionTierDisplayName,
+                CommonUIStrings.TranslationTierDisplayName });
+            _cboAudacityLabelTier.Size = _cboAudacityLabelTier.PreferredSize;
+			if (_radioButtonAudacity.Checked)
+                _cboAudacityLabelTier.SelectedIndex = 0;
+        }
+
+        /// ------------------------------------------------------------------------------------
 		private void HandleGetStartedButtonClick(object sender, EventArgs e)
 		{
 			_buttonGetStarted.Enabled = false;
@@ -126,7 +145,9 @@ namespace SayMore.Transcription.UI
 					"DialogBoxes.Transcription.CreateAnnotationFileDlg.AudacityLabelOpenFileDlg.FileTypeString",
 					"Audacity Label File (*.txt)|*.txt");
 
-				newAnnotationFile = GetAudacityOrElanFile(caption, filetype);
+				newAnnotationFile = GetAudacityOrElanFile(caption, filetype,
+                    _cboAudacityLabelTier.SelectedIndex == 0 ? TierType.Transcription :
+                        TierType.FreeTranslation);
 				Settings.Default.DefaultSegmentationMethod = 3;
 			}
 			else if (_radioButtonAutoSegmenter.Checked)
@@ -143,7 +164,11 @@ namespace SayMore.Transcription.UI
 		}
 
 		/// ------------------------------------------------------------------------------------
-		private string GetAudacityOrElanFile(string caption, string filter)
+		/// <param name="tierType">If creating from an Audacity file, the tier type specifies
+		/// which tier the label text goes into.</param>
+        /// ------------------------------------------------------------------------------------
+		private string GetAudacityOrElanFile(string caption, string filter,
+            TierType tierType = default)
 		{
 			using (var dlg = new OpenFileDialog())
 			{
@@ -156,8 +181,20 @@ namespace SayMore.Transcription.UI
 					"All Files (*.*)|*.*");
 
 				return (dlg.ShowDialog() != DialogResult.OK ? null :
-					AnnotationFileHelper.CreateFileFromFile(dlg.FileName, _file.PathToAnnotatedFile));
+					AnnotationFileHelper.CreateFileFromFile(dlg.FileName, _file.PathToAnnotatedFile, tierType));
 			}
 		}
-	}
+
+        private void _radioButtonAudacity_CheckedChanged(object sender, EventArgs e)
+        {
+            _lblAudacityLabelTier.Enabled = _cboAudacityLabelTier.Enabled =
+                _radioButtonAudacity.Checked;
+
+            if (_radioButtonAudacity.Checked && _cboAudacityLabelTier.Items.Count > 0 &&
+                _cboAudacityLabelTier.SelectedIndex < 0)
+            {
+                _cboAudacityLabelTier.SelectedIndex = 0;
+            }
+        }
+    }
 }

--- a/src/SayMore/Transcription/UI/ComponentEditors/StartAnnotatingEditor.cs
+++ b/src/SayMore/Transcription/UI/ComponentEditors/StartAnnotatingEditor.cs
@@ -61,8 +61,9 @@ namespace SayMore.Transcription.UI
 			_radioButtonCarefulSpeech.Font = Program.DialogFont;
 			_radioButtonElan.Font = Program.DialogFont;
 			_radioButtonAudacity.Font = Program.DialogFont;
+			_labelAudacityLabelTier.Font = Program.DialogFont;
 			_radioButtonAutoSegmenter.Font = Program.DialogFont;
-		}
+        }
 
 		/// ------------------------------------------------------------------------------------
 		public override bool IsOKToShow
@@ -187,7 +188,7 @@ namespace SayMore.Transcription.UI
 
         private void _radioButtonAudacity_CheckedChanged(object sender, EventArgs e)
         {
-            _lblAudacityLabelTier.Enabled = _cboAudacityLabelTier.Enabled =
+            _labelAudacityLabelTier.Enabled = _cboAudacityLabelTier.Enabled =
                 _radioButtonAudacity.Checked;
 
             if (_radioButtonAudacity.Checked && _cboAudacityLabelTier.Items.Count > 0 &&

--- a/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.cs
+++ b/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.cs
@@ -44,10 +44,10 @@ namespace SayMore.Transcription.UI
 			InitializeComponent();
 
 			_labelTranscriptionColumnHeadingText.Text =
-				string.Format(_labelTranscriptionColumnHeadingText.Text, LocalizationManager.GetString("SessionsView.Transcription.TierDisplayNames.Transcription", "Transcription"));
+				string.Format(_labelTranscriptionColumnHeadingText.Text, CommonUIStrings.TranscriptionTierDisplayName);
 
 			_labelFreeTranslationColumnHeadingText.Text =
-				string.Format(_labelFreeTranslationColumnHeadingText.Text, LocalizationManager.GetString("SessionsView.Transcription.TierDisplayNames.FreeTranslation", "Free Translation"));
+				string.Format(_labelFreeTranslationColumnHeadingText.Text, CommonUIStrings.TranslationTierDisplayName);
 
 			_labelOverview.Font = Program.DialogFont;
 			_labelTranscriptionColumnHeadingText.Font = Program.DialogFont;

--- a/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
+++ b/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -14,7 +13,6 @@ using SayMore.Model.Files;
 using SayMore.Model;
 using SayMore.UI.ComponentEditors;
 using SayMore.UI.LowLevelControls;
-using SIL.Extensions;
 
 namespace SayMore.UI.ElementListScreen
 {

--- a/src/SayMore/UI/SplashScreenForm.Designer.cs
+++ b/src/SayMore/UI/SplashScreenForm.Designer.cs
@@ -187,7 +187,7 @@ namespace SayMore.UI
 			this.label1.Name = "label1";
 			this.label1.Size = new System.Drawing.Size(159, 13);
 			this.label1.TabIndex = 7;
-			this.label1.Text = "© 2011-2022 SIL International";
+			this.label1.Text = "© 2011-2023 SIL International";
 			// 
 			// SplashScreenForm
 			// 


### PR DESCRIPTION
Requested here: https://community.software.sil.org/t/saymore-import-of-audacity-track-label-can-we-have-it-go-to-free-translation/7095/5

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/170)
<!-- Reviewable:end -->
