### PR TITLE
SP-2303: Fixed process to convert source media to standard PCM WAV files

### DIFF
--- a/src/SayMore/MediaUtils/Audio/AudioUtils.cs
+++ b/src/SayMore/MediaUtils/Audio/AudioUtils.cs
@@ -337,19 +337,10 @@ namespace SayMore.Media.Audio
 		private static bool DoPcmConversion(string inputMediaFile, string outputAudioFile,
 			WaveFormat preferredOutputFormat)
 		{
-			string output;
-			var result = MPlayerHelper.CreatePcmAudioFromMediaFile(inputMediaFile,
-				outputAudioFile, preferredOutputFormat, out output);
-			if ((result & MPlayerHelper.ConversionResult.FinishedConverting) != 0)
-			{
-				// Possibly succeeded
-				if ((result & MPlayerHelper.ConversionResult.PossibleError) > 0)
-					ReportPossibleConversionProblem(output);
-				return true;
-			}
-
+			// First try to convert using FFmpeg. We used to tyr MPlayer first, but FFmpeg isa
+			// probably more reliable and.or faster than MPlayer.
 			var model = new ConvertMediaDlgViewModel(inputMediaFile,
-					ConvertMediaDlg.GetFactoryExtractToStandardPcmConversionName());
+				ConvertMediaDlg.GetFactoryExtractToStandardPcmConversionName());
 
 			model.BeginConversion(null, outputAudioFile, preferredOutputFormat);
 
@@ -359,7 +350,15 @@ namespace SayMore.Media.Audio
 			{
 				if ((model.ConversionState & ConvertMediaUIState.PossibleError) > 0)
 					ReportPossibleConversionProblem(model.ConversionOutput);
-				return File.Exists(outputAudioFile);
+
+				if (File.Exists(outputAudioFile))
+				{
+					if (GetIsFileStandardPcm(outputAudioFile))
+						return true;
+					// Don't want to leave around a converted file if it isn't really
+					// a "standard" PCM Wav file.
+					File.Delete(outputAudioFile);
+				}
 			}
 
 			if (finishedState == ConvertMediaUIState.ConversionFailed)
@@ -367,6 +366,24 @@ namespace SayMore.Media.Audio
 				var e = model.ConversionException;
 				if (e != null)
 					throw e;
+			}
+
+			var result = MPlayerHelper.CreatePcmAudioFromMediaFile(inputMediaFile,
+				outputAudioFile, preferredOutputFormat, out var output);
+			if ((result & MPlayerHelper.ConversionResult.FinishedConverting) != 0)
+			{
+				// Possibly succeeded
+				if ((result & MPlayerHelper.ConversionResult.PossibleError) > 0)
+					ReportPossibleConversionProblem(output);
+
+				if (File.Exists(outputAudioFile))
+				{
+					if (GetIsFileStandardPcm(outputAudioFile))
+						return true;
+					// Don't want to leave around a converted file if it isn't really
+					// a "standard" PCM Wav file.
+					File.Delete(outputAudioFile);
+				}
 			}
 
 			return false;

--- a/src/SayMore/MediaUtils/Audio/AudioUtils.cs
+++ b/src/SayMore/MediaUtils/Audio/AudioUtils.cs
@@ -15,6 +15,7 @@ using SIL.Windows.Forms.Miscellaneous;
 using SayMore.Media.MPlayer;
 using SayMore.Properties;
 using SayMore.UI;
+using SIL.IO;
 
 namespace SayMore.Media.Audio
 {
@@ -337,7 +338,7 @@ namespace SayMore.Media.Audio
 		private static bool DoPcmConversion(string inputMediaFile, string outputAudioFile,
 			WaveFormat preferredOutputFormat)
 		{
-			// First try to convert using FFmpeg. We used to tyr MPlayer first, but FFmpeg isa
+			// First try to convert using FFmpeg. We used to try MPlayer first, but FFmpeg is
 			// probably more reliable and.or faster than MPlayer.
 			var model = new ConvertMediaDlgViewModel(inputMediaFile,
 				ConvertMediaDlg.GetFactoryExtractToStandardPcmConversionName());
@@ -357,7 +358,7 @@ namespace SayMore.Media.Audio
 						return true;
 					// Don't want to leave around a converted file if it isn't really
 					// a "standard" PCM Wav file.
-					File.Delete(outputAudioFile);
+					RobustFile.Delete(outputAudioFile);
 				}
 			}
 
@@ -382,7 +383,7 @@ namespace SayMore.Media.Audio
 						return true;
 					// Don't want to leave around a converted file if it isn't really
 					// a "standard" PCM Wav file.
-					File.Delete(outputAudioFile);
+					RobustFile.Delete(outputAudioFile);
 				}
 			}
 

--- a/src/SayMore/MediaUtils/MPlayer/MPlayerHelper.cs
+++ b/src/SayMore/MediaUtils/MPlayer/MPlayerHelper.cs
@@ -120,7 +120,7 @@ namespace SayMore.Media.MPlayer
 			yield return "-nocorrect-pts";
 			yield return "-vo null";
 			yield return "-vc null";
-			yield return string.Format("-af channels={0}", preferredOutputFormat.Channels);
+			yield return string.Format("-af channels={0} -af format=s16le", preferredOutputFormat.Channels);
 			yield return string.Format("-srate {0}", preferredOutputFormat.SampleRate);
 			yield return string.Format("-ao pcm:fast:file=%{0}%\"{1}\"", audioOutPath.Length, audioOutPath);
 		}

--- a/src/SayMore/ProjectContext.cs
+++ b/src/SayMore/ProjectContext.cs
@@ -15,6 +15,7 @@ using SayMore.Properties;
 using SayMore.UI.ElementListScreen;
 using SayMore.UI.Overview;
 using SayMore.UI.ProjectWindow;
+using SIL.IO;
 using SIL.Reporting;
 
 namespace SayMore
@@ -137,7 +138,7 @@ namespace SayMore
 							         !AudioUtils.GetIsFileStandardPcm(f)))
 						{
 							Analytics.Track("Delete bogus Standard Audio file");
-							File.Delete(bogusStandardAudioFile);
+							RobustFile.Delete(bogusStandardAudioFile);
 						}
 
 						// Note: There never was a version 1, but it felt wrong to start with version 1

--- a/src/SayMore/ProjectContext.cs
+++ b/src/SayMore/ProjectContext.cs
@@ -106,24 +106,6 @@ namespace SayMore
 				if (sessionFile == null)
 					return;
 
-				// SP-2303: SayMore 3.5.0 (released 3/22/2023) had a bug whereby it could convert
-				// media files to a non-standard (IEEE Float) PCM format that could not be
-				// annotated. This code checks for and deletes any such files. Because it takes
-				// some time to check this, we only consider files that might have been created
-				// after the release date. It would be nice to only do this check if we could know
-				// that version 3.5.0 had been installed, but I'm not sure we can reliably and
-				// easily detect this. (Maybe by looking for the settings file?). At some point,
-				// when we think any existing problems are likely to have been cleaned up, we
-				// might consider removing this code.
-				foreach (var bogusStandardAudioFile in filesInDir.Where(f =>
-					         f.EndsWith(Settings.Default.StandardAudioFileSuffix) &&
-					         new FileInfo(f).CreationTime >= new DateTime(2023, 3, 21) && 
-					         !AudioUtils.GetIsFileStandardPcm(f)))
-				{
-					Analytics.Track("Delete bogus Standard Audio file");
-					File.Delete(bogusStandardAudioFile);
-				}
-
 				// SP-2260:We really NEVER want to deal with files that start with ._, but since
 				// previous versions of SayMore and certain other ways of creating session files
 				// could have resulted in session files that do, we will not exclude ._*.meta
@@ -136,6 +118,34 @@ namespace SayMore
 				var sessionDoc = LoadXmlDocument(sessionFile);
 				LoadContributors(sessionDoc, namesList, nameRolesList, contributorLists);
 				var root = sessionDoc.DocumentElement;
+				
+				if (root != null)
+				{
+					if (root.Attributes.GetNamedItem("version") == null)
+					{
+						// SP-2303: SayMore 3.5.0 (released 3/22/2023) had a bug whereby it could convert
+						// media files to a non-standard (IEEE Float) PCM format that could not be
+						// annotated. This code checks for and deletes any such files. Because it takes
+						// some time to check this, we only consider files that might have been created
+						// after the release date. It would be nice to only do this check if we could know
+						// that version 3.5.0 had been installed, but I'm not sure we can reliably and
+						// easily detect this. (Maybe by looking for the settings file?). But using this
+						// version number, we can at least avoid checking again.
+						foreach (var bogusStandardAudioFile in filesInDir.Where(f =>
+							         f.EndsWith(Settings.Default.StandardAudioFileSuffix) &&
+							         new FileInfo(f).CreationTime >= new DateTime(2023, 3, 21) && 
+							         !AudioUtils.GetIsFileStandardPcm(f)))
+						{
+							Analytics.Track("Delete bogus Standard Audio file");
+							File.Delete(bogusStandardAudioFile);
+						}
+
+						// Note: There never was a version 1, but it felt wrong to start with version 1
+						// after more than a decade of existence.
+						root.SetAttribute("version", "2.0");
+					}
+				}
+
 				var contributionsNode = root?.SelectSingleNode(SessionFileType.kContributionsFieldName);
 				contributionsNode?.ParentNode?.RemoveChild(contributionsNode); //Remove the contributions node
 				if (root?.LastChild == null)


### PR DESCRIPTION
Changed to use FFmpeg as primary and Mplayer as secondary. Added command-line switch to MPlayer to prevent conversion of media to IEEE float WAV files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/174)
<!-- Reviewable:end -->
