### PR TITLE
SP-2307: prevent Invoke before MediaPlayer window handle is created

### DIFF
--- a/src/SayMore/MediaUtils/MPlayer/MediaPlayer.cs
+++ b/src/SayMore/MediaUtils/MPlayer/MediaPlayer.cs
@@ -43,11 +43,8 @@ namespace SayMore.Media.MPlayer
 			}
 
 			_viewModel = viewModel;
-			_viewModel.MediaQueued += HandleMediaQueued;
-			_viewModel.PlaybackStarted += HandleMediaPlayStarted;
-			_viewModel.PlaybackPaused = delegate { Invoke((Action)HandlePlaybackPausedResumed); };
-			_viewModel.PlaybackResumed = delegate { Invoke((Action)HandlePlaybackPausedResumed); };
-			_viewModel.PlaybackPositionChanged = ViewModelPlaybackPositionChanged;
+			if (IsHandleCreated)
+				SetUpViewModelEventHandlers();
 
 			UpdateButtons();
 			_volumePopup.VolumeLevel = _viewModel.Volume;
@@ -55,7 +52,19 @@ namespace SayMore.Media.MPlayer
 			_videoPanel.SetPlayerViewModel(_viewModel);
 		}
 
-        private void ViewModelPlaybackPositionChanged(float pos)
+		private void SetUpViewModelEventHandlers()
+		{
+			// To avoid possible race condition problem, unregister before registering
+			_viewModel.MediaQueued -= HandleMediaQueued;
+			_viewModel.MediaQueued += HandleMediaQueued;
+			_viewModel.PlaybackStarted -= HandleMediaPlayStarted;
+			_viewModel.PlaybackStarted += HandleMediaPlayStarted;
+			_viewModel.PlaybackPaused = delegate { Invoke((Action)HandlePlaybackPausedResumed); };
+			_viewModel.PlaybackResumed = delegate { Invoke((Action)HandlePlaybackPausedResumed); };
+			_viewModel.PlaybackPositionChanged = ViewModelPlaybackPositionChanged;
+		}
+
+		private void ViewModelPlaybackPositionChanged(float pos)
         {
             try
             {
@@ -104,19 +113,20 @@ namespace SayMore.Media.MPlayer
 		/// problem.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		private new bool DesignMode
+		private new bool DesignMode =>
+			base.DesignMode || GetService(typeof(IDesignerHost)) != null ||
+			LicenseManager.UsageMode == LicenseUsageMode.Designtime;
+
+		protected override void OnHandleCreated(EventArgs e)
 		{
-			get
-			{
-				return (base.DesignMode || GetService(typeof(IDesignerHost)) != null) ||
-					(LicenseManager.UsageMode == LicenseUsageMode.Designtime);
-			}
+			base.OnHandleCreated(e);
+			if (_viewModel != null)
+				SetUpViewModelEventHandlers();
 		}
 
 		/// ------------------------------------------------------------------------------------
 		protected override void OnHandleDestroyed(EventArgs e)
 		{
-			//_reportPlayerOutput = null;
 			_viewModel.ShutdownMPlayerProcess();
 			base.OnHandleDestroyed(e);
 		}
@@ -197,22 +207,11 @@ namespace SayMore.Media.MPlayer
 			_viewModel.SetVolume(((VolumePopup)sender).VolumeLevel);
 		}
 
-		///// ------------------------------------------------------------------------------------
-		//private void HandleSliderTimeBeforeUserMovingThumb(object sender, float newValue)
-		//{
-		//    if (!_viewModel.IsPaused)
-		//        HandleButtonPauseClick(null, null);
-
-		//    _viewModel.PlaybackPositionChanged -= HandlePlaybackPositionChanged;
-		//    _sliderTime.ValueChanged += HandleSliderTimeValueChanged;
-		//}
-
 		/// ------------------------------------------------------------------------------------
 		private void HandleSliderTimeAfterUserMovingThumb(object sender, EventArgs e)
 		{
 			_sliderTime.ValueChanged -= HandleSliderTimeValueChanged;
 			_viewModel.Seek(_sliderTime.Value);
-			_viewModel.PlaybackPositionChanged += HandlePlaybackPositionChanged;
 		}
 
 		/// ------------------------------------------------------------------------------------


### PR DESCRIPTION
Changed sequence of setup operations in MediaPlayer to prevent setting handlers that might be called and Invoke an operation before the window handle is created.
Note: I have not found a way to reproduce this crash, but it was reported twice by the same user in quick succession.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/176)
<!-- Reviewable:end -->
