### PR TITLE
SP-2332: Prevented NullReferenceException when clicking away during playback of generated oral annotations

### DIFF
--- a/src/SayMore/Transcription/UI/ComponentEditors/OralAnnotationEditor.cs
+++ b/src/SayMore/Transcription/UI/ComponentEditors/OralAnnotationEditor.cs
@@ -8,6 +8,7 @@ using SayMore.Model.Files;
 using SayMore.Media.MPlayer;
 using SayMore.UI.ComponentEditors;
 using SIL.Windows.Forms;
+using NAudio.SoundFont;
 
 namespace SayMore.Transcription.UI
 {
@@ -259,7 +260,7 @@ namespace SayMore.Transcription.UI
 			_oralAnnotationWaveViewer.CloseAudioStream();
 
 			_file.GenerateOralAnnotationFile(this, ComponentFile.GenerateOption.RegenerateNow);
-			SetComponentFile(_file);
+			HandleOralAnnotationFileGenerated(true);
 			_oralAnnotationWaveViewer.Invalidate(true);
 
 			_buttonRegenerate.Enabled = true;


### PR DESCRIPTION
Also fixed problem that prevented playing regenerated file.
Included some Resharper-suggested code cleanup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/184)
<!-- Reviewable:end -->
