### PR TITLE
SP-2353: Upgraded to latest SILL Dlls (currently beta)

### DIFF
--- a/build/SayMore.proj
+++ b/build/SayMore.proj
@@ -3,9 +3,9 @@
 	<RootDir Condition="'$(teamcity_version)' == ''">$(MSBuildProjectDirectory)\..</RootDir>
 	<RootDir Condition="'$(teamcity_version)' != ''">$(teamcity_build_checkoutDir)</RootDir>
 	<BUILD_NUMBER Condition="'$(BUILD_NUMBER)'==''">3.5.0</BUILD_NUMBER>
-	<BuildTasksDll Condition="Exists('$(RootDir)/packages/SIL.BuildTasks.3.0.0/tools/SIL.BuildTasks.dll')">$(RootDir)/packages/SIL.BuildTasks.3.0.0/tools/SIL.BuildTasks.dll</BuildTasksDll>
-	<BuildTasksDll Condition="!Exists('$(RootDir)/packages/SIL.BuildTasks.3.0.0/tools/SIL.BuildTasks.dll')">$(RootDir)/packages/SIL.BuildTasks/tools/SIL.BuildTasks.dll</BuildTasksDll>
-	<SILReleaseTasksProps>$(RootDir)/packages/SIL.ReleaseTasks.3.0.0/build/SIL.ReleaseTasks.props</SILReleaseTasksProps>
+	<BuildTasksDll Condition="Exists('$(RootDir)/packages/SIL.BuildTasks.3.1.0/tools/SIL.BuildTasks.dll')">$(RootDir)/packages/SIL.BuildTasks.3.1.0/tools/SIL.BuildTasks.dll</BuildTasksDll>
+	<BuildTasksDll Condition="!Exists('$(RootDir)/packages/SIL.BuildTasks.3.1.0/tools/SIL.BuildTasks.dll')">$(RootDir)/packages/SIL.BuildTasks/tools/SIL.BuildTasks.dll</BuildTasksDll>
+	<SILReleaseTasksProps>$(RootDir)/packages/SIL.ReleaseTasks.3.1.0/build/SIL.ReleaseTasks.props</SILReleaseTasksProps>
 	<Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
 	<RestartBuild Condition="!Exists('$(BuildTasksDll)') Or !Exists('$(SILReleaseTasksProps)')">true</RestartBuild>
 	<RestartBuild Condition="Exists('$(BuildTasksDll)') And Exists('$(SILReleaseTasksProps)')">false</RestartBuild>

--- a/src/SayMore/SayMore.csproj
+++ b/src/SayMore/SayMore.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.props" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.props')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.props" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.props')" />
+  <Import Project="..\..\packages\SIL.ReleaseTasks.3.1.0\build\SIL.ReleaseTasks.props" Condition="Exists('..\..\packages\SIL.ReleaseTasks.3.1.0\build\SIL.ReleaseTasks.props')" />
+  <Import Project="..\..\packages\SIL.BuildTasks.3.1.0\build\SIL.BuildTasks.props" Condition="Exists('..\..\packages\SIL.BuildTasks.3.1.0\build\SIL.BuildTasks.props')" />
   <Import Project="..\..\packages\icu.net.3.0.0\build\icu.net.props" Condition="Exists('..\..\packages\icu.net.3.0.0\build\icu.net.props')" />
-  <Import Project="..\..\packages\SIL.ReleaseTasks.3.0.0\build\SIL.ReleaseTasks.props" Condition="Exists('..\..\packages\SIL.ReleaseTasks.3.0.0\build\SIL.ReleaseTasks.props')" />
-  <Import Project="..\..\packages\SIL.BuildTasks.3.0.0\build\SIL.BuildTasks.props" Condition="Exists('..\..\packages\SIL.BuildTasks.3.0.0\build\SIL.BuildTasks.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -117,8 +117,19 @@
     <Reference Include="Instances, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Instances.3.0.1\lib\netstandard2.0\Instances.dll</HintPath>
     </Reference>
-    <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\L10NSharp.7.0.0\lib\net461\L10NSharp.dll</HintPath>
+    <Reference Include="Keyman10Interop, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\KeymanLegacyBundle.1.0.0\lib\Keyman10Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Keyman7Interop, Version=1.4.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\KeymanLegacyBundle.1.0.0\lib\Keyman7Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="KeymanLink, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\KeymanLegacyBundle.1.0.0\lib\KeymanLink.dll</HintPath>
+    </Reference>
+    <Reference Include="L10NSharp, Version=8.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\L10NSharp.8.0.0-beta0005\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="Markdig.Signed, Version=0.37.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Markdig.Signed.0.37.0\lib\net462\Markdig.Signed.dll</HintPath>
@@ -169,32 +180,32 @@
     <Reference Include="Serialization.NET, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serialization.NET.1.4.1\lib\netstandard2.0\Serialization.NET.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Archiving, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Archiving.15.0.0\lib\net462\SIL.Archiving.dll</HintPath>
+    <Reference Include="SIL.Archiving, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Archiving.16.0.0-beta0061\lib\net462\SIL.Archiving.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Core, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Core.15.0.0\lib\net462\SIL.Core.dll</HintPath>
+    <Reference Include="SIL.Core, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Core.16.0.0-beta0061\lib\net462\SIL.Core.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Core.Desktop, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Core.Desktop.15.0.0\lib\net462\SIL.Core.Desktop.dll</HintPath>
+    <Reference Include="SIL.Core.Desktop, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Core.Desktop.16.0.0-beta0061\lib\net462\SIL.Core.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Media, Version=15.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Media.15.0.0\lib\net462\SIL.Media.dll</HintPath>
+    <Reference Include="SIL.Media, Version=16.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Media.16.0.0-beta0061\lib\net462\SIL.Media.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.15.0.0\lib\net462\SIL.Windows.Forms.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\lib\net462\SIL.Windows.Forms.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.Archiving, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.Archiving.15.0.0\lib\net462\SIL.Windows.Forms.Archiving.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.Archiving, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.Archiving.16.0.0-beta0061\lib\net462\SIL.Windows.Forms.Archiving.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.Keyboarding, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\lib\net462\SIL.Windows.Forms.Keyboarding.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.Keyboarding, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\lib\net462\SIL.Windows.Forms.Keyboarding.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.WritingSystems, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.WritingSystems.15.0.0\lib\net462\SIL.Windows.Forms.WritingSystems.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.WritingSystems, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.WritingSystems.16.0.0-beta0061\lib\net462\SIL.Windows.Forms.WritingSystems.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.WritingSystems, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.WritingSystems.15.0.0\lib\net462\SIL.WritingSystems.dll</HintPath>
+    <Reference Include="SIL.WritingSystems, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.WritingSystems.16.0.0-beta0061\lib\net462\SIL.WritingSystems.dll</HintPath>
     </Reference>
     <Reference Include="Sovran.NET, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Sovran.NET.1.4.0\lib\netstandard2.0\Sovran.NET.dll</HintPath>
@@ -1345,23 +1356,23 @@
     <Error Condition="!Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets'))" />
     <Error Condition="!Exists('..\..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets'))" />
     <Error Condition="!Exists('..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.BuildTasks.3.0.0\build\SIL.BuildTasks.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.BuildTasks.3.0.0\build\SIL.BuildTasks.props'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.ReleaseTasks.3.0.0\build\SIL.ReleaseTasks.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.ReleaseTasks.3.0.0\build\SIL.ReleaseTasks.props'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.ReleaseTasks.3.0.0\build\SIL.ReleaseTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.ReleaseTasks.3.0.0\build\SIL.ReleaseTasks.targets'))" />
     <Error Condition="!Exists('..\..\packages\icu.net.3.0.0\build\icu.net.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\icu.net.3.0.0\build\icu.net.props'))" />
     <Error Condition="!Exists('..\..\packages\icu.net.3.0.0\build\icu.net.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\icu.net.3.0.0\build\icu.net.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.props'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.15.0.0\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.15.0.0\build\SIL.Windows.Forms.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Media.15.0.0\build\SIL.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Media.15.0.0\build\SIL.Media.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.BuildTasks.3.1.0\build\SIL.BuildTasks.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.BuildTasks.3.1.0\build\SIL.BuildTasks.props'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.ReleaseTasks.3.1.0\build\SIL.ReleaseTasks.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.ReleaseTasks.3.1.0\build\SIL.ReleaseTasks.props'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.ReleaseTasks.3.1.0\build\SIL.ReleaseTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.ReleaseTasks.3.1.0\build\SIL.ReleaseTasks.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Media.16.0.0-beta0061\build\SIL.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Media.16.0.0-beta0061\build\SIL.Media.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.props'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\build\SIL.Windows.Forms.targets'))" />
   </Target>
   <Import Project="..\..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets" Condition="Exists('..\..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets')" />
   <Import Project="..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets" Condition="Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" />
   <Import Project="..\..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets" Condition="Exists('..\..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets')" />
   <Import Project="..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets" Condition="Exists('..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" />
-  <Import Project="..\..\packages\SIL.ReleaseTasks.3.0.0\build\SIL.ReleaseTasks.targets" Condition="Exists('..\..\packages\SIL.ReleaseTasks.3.0.0\build\SIL.ReleaseTasks.targets')" />
   <Import Project="..\..\packages\icu.net.3.0.0\build\icu.net.targets" Condition="Exists('..\..\packages\icu.net.3.0.0\build\icu.net.targets')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.targets')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.15.0.0\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.15.0.0\build\SIL.Windows.Forms.targets')" />
-  <Import Project="..\..\packages\SIL.Media.15.0.0\build\SIL.Media.targets" Condition="Exists('..\..\packages\SIL.Media.15.0.0\build\SIL.Media.targets')" />
+  <Import Project="..\..\packages\SIL.ReleaseTasks.3.1.0\build\SIL.ReleaseTasks.targets" Condition="Exists('..\..\packages\SIL.ReleaseTasks.3.1.0\build\SIL.ReleaseTasks.targets')" />
+  <Import Project="..\..\packages\SIL.Media.16.0.0-beta0061\build\SIL.Media.targets" Condition="Exists('..\..\packages\SIL.Media.16.0.0-beta0061\build\SIL.Media.targets')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.targets')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\build\SIL.Windows.Forms.targets')" />
 </Project>

--- a/src/SayMore/UI/ComponentEditors/ContributorsEditor.cs
+++ b/src/SayMore/UI/ComponentEditors/ContributorsEditor.cs
@@ -43,6 +43,8 @@ namespace SayMore.UI.ComponentEditors
 			dataGridView.Columns[dataGridView.Columns.Add("date", "date")].Visible = false;
 			_model.ContributorsGridSettings = GridSettings.Create(dataGridView);
 
+			SetComponentFile(file);
+
 			_contributorsControl = new ContributorsListControl(_model)
 			{
 				Dock = DockStyle.Fill,
@@ -63,8 +65,6 @@ namespace SayMore.UI.ComponentEditors
 			}
 
 			file.AfterSave += File_AfterSave;
-
-			SetComponentFile(file);
 
 			personInformant.PersonUiIdChanged += HandlePersonsUiIdChanged;
 		}

--- a/src/SayMore/packages.config
+++ b/src/SayMore/packages.config
@@ -16,7 +16,8 @@
   <package id="icu.net" version="3.0.0" targetFramework="net462" />
   <package id="Icu4c.Win.Min" version="59.1.7" targetFramework="net462" />
   <package id="Instances" version="3.0.1" targetFramework="net462" />
-  <package id="L10NSharp" version="7.0.0" targetFramework="net462" />
+  <package id="KeymanLegacyBundle" version="1.0.0" targetFramework="net462" />
+  <package id="L10NSharp" version="8.0.0-beta0005" targetFramework="net462" />
   <package id="Markdig.Signed" version="0.37.0" targetFramework="net462" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.1" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net462" />
@@ -33,18 +34,18 @@
   <package id="PangoSharp-signed" version="3.22.24.37" targetFramework="net462" />
   <package id="Segment.Analytics.CSharp" version="2.4.2" targetFramework="net462" />
   <package id="Serialization.NET" version="1.4.1" targetFramework="net462" />
-  <package id="SIL.Archiving" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.BuildTasks" version="3.0.0" targetFramework="net462" />
-  <package id="SIL.Core" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Core.Desktop" version="15.0.0" targetFramework="net462" />
+  <package id="SIL.Archiving" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.BuildTasks" version="3.1.0" targetFramework="net462" />
+  <package id="SIL.Core" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Core.Desktop" version="16.0.0-beta0061" targetFramework="net462" />
   <package id="SIL.DesktopAnalytics" version="6.0.1" targetFramework="net462" />
-  <package id="SIL.Media" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.ReleaseTasks" version="3.0.0" targetFramework="net462" />
-  <package id="SIL.Windows.Forms" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Windows.Forms.Archiving" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Windows.Forms.Keyboarding" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Windows.Forms.WritingSystems" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.WritingSystems" version="15.0.0" targetFramework="net462" />
+  <package id="SIL.Media" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.ReleaseTasks" version="3.1.0" targetFramework="net462" />
+  <package id="SIL.Windows.Forms" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Windows.Forms.Archiving" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Windows.Forms.Keyboarding" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Windows.Forms.WritingSystems" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.WritingSystems" version="16.0.0-beta0061" targetFramework="net462" />
   <package id="Sovran.NET" version="1.4.0" targetFramework="net462" />
   <package id="Spart" version="1.0.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.6.0" targetFramework="net462" />

--- a/src/SayMoreTests/SayMoreTests.csproj
+++ b/src/SayMoreTests/SayMoreTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.props" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.props')" />
   <Import Project="..\..\packages\NUnit.3.14.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.14.0\build\NUnit.props')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.props" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.props')" />
   <Import Project="..\..\packages\icu.net.3.0.0\build\icu.net.props" Condition="Exists('..\..\packages\icu.net.3.0.0\build\icu.net.props')" />
   <Import Project="..\..\packages\NUnit3TestAdapter.4.6.0\build\net462\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.4.6.0\build\net462\NUnit3TestAdapter.props')" />
   <PropertyGroup>
@@ -101,8 +101,19 @@
     <Reference Include="Instances, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Instances.3.0.1\lib\netstandard2.0\Instances.dll</HintPath>
     </Reference>
-    <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\L10NSharp.7.0.0\lib\net461\L10NSharp.dll</HintPath>
+    <Reference Include="Keyman10Interop, Version=10.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\KeymanLegacyBundle.1.0.0\lib\Keyman10Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Keyman7Interop, Version=1.4.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\KeymanLegacyBundle.1.0.0\lib\Keyman7Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="KeymanLink, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\KeymanLegacyBundle.1.0.0\lib\KeymanLink.dll</HintPath>
+    </Reference>
+    <Reference Include="L10NSharp, Version=8.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\L10NSharp.8.0.0-beta0005\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="Markdig.Signed, Version=0.37.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Markdig.Signed.0.37.0\lib\net462\Markdig.Signed.dll</HintPath>
@@ -143,29 +154,29 @@
     <Reference Include="PangoSharp, Version=3.22.24.37, Culture=neutral, PublicKeyToken=313398f2149d753f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\PangoSharp-signed.3.22.24.37\lib\netstandard2.0\PangoSharp.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Archiving, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Archiving.15.0.0\lib\net462\SIL.Archiving.dll</HintPath>
+    <Reference Include="SIL.Archiving, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Archiving.16.0.0-beta0061\lib\net462\SIL.Archiving.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Core, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Core.15.0.0\lib\net462\SIL.Core.dll</HintPath>
+    <Reference Include="SIL.Core, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Core.16.0.0-beta0061\lib\net462\SIL.Core.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Core.Desktop, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Core.Desktop.15.0.0\lib\net462\SIL.Core.Desktop.dll</HintPath>
+    <Reference Include="SIL.Core.Desktop, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Core.Desktop.16.0.0-beta0061\lib\net462\SIL.Core.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Media, Version=15.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Media.15.0.0\lib\net462\SIL.Media.dll</HintPath>
+    <Reference Include="SIL.Media, Version=16.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Media.16.0.0-beta0061\lib\net462\SIL.Media.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.TestUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.TestUtilities.15.0.0\lib\net462\SIL.TestUtilities.dll</HintPath>
+    <Reference Include="SIL.TestUtilities, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.TestUtilities.16.0.0-beta0061\lib\net462\SIL.TestUtilities.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.15.0.0\lib\net462\SIL.Windows.Forms.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\lib\net462\SIL.Windows.Forms.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.Keyboarding, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\lib\net462\SIL.Windows.Forms.Keyboarding.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.Keyboarding, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\lib\net462\SIL.Windows.Forms.Keyboarding.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.WritingSystems, Version=15.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.WritingSystems.15.0.0\lib\net462\SIL.WritingSystems.dll</HintPath>
+    <Reference Include="SIL.WritingSystems, Version=16.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.WritingSystems.16.0.0-beta0061\lib\net462\SIL.WritingSystems.dll</HintPath>
     </Reference>
     <Reference Include="Spart, Version=1.0.0.0, Culture=neutral, PublicKeyToken=14d24e064e474331, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Spart.1.0.0\lib\net461\Spart.dll</HintPath>
@@ -432,19 +443,19 @@
     <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.4.6.0\build\net462\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.4.6.0\build\net462\NUnit3TestAdapter.props'))" />
     <Error Condition="!Exists('..\..\packages\icu.net.3.0.0\build\icu.net.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\icu.net.3.0.0\build\icu.net.props'))" />
     <Error Condition="!Exists('..\..\packages\icu.net.3.0.0\build\icu.net.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\icu.net.3.0.0\build\icu.net.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.props'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.15.0.0\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.15.0.0\build\SIL.Windows.Forms.targets'))" />
     <Error Condition="!Exists('..\..\packages\NUnit.3.14.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.14.0\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Media.15.0.0\build\SIL.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Media.15.0.0\build\SIL.Media.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Media.16.0.0-beta0061\build\SIL.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Media.16.0.0-beta0061\build\SIL.Media.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.props'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\build\SIL.Windows.Forms.targets'))" />
   </Target>
   <Import Project="..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets" Condition="Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" />
   <Import Project="..\..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets" Condition="Exists('..\..\packages\Mono.Unix.7.1.0-final.1.21458.1\build\Mono.Unix.targets')" />
   <Import Project="..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets" Condition="Exists('..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" />
   <Import Project="..\..\packages\icu.net.3.0.0\build\icu.net.targets" Condition="Exists('..\..\packages\icu.net.3.0.0\build\icu.net.targets')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.15.0.0\build\SIL.Windows.Forms.Keyboarding.targets')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.15.0.0\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.15.0.0\build\SIL.Windows.Forms.targets')" />
-  <Import Project="..\..\packages\SIL.Media.15.0.0\build\SIL.Media.targets" Condition="Exists('..\..\packages\SIL.Media.15.0.0\build\SIL.Media.targets')" />
+  <Import Project="..\..\packages\SIL.Media.16.0.0-beta0061\build\SIL.Media.targets" Condition="Exists('..\..\packages\SIL.Media.16.0.0-beta0061\build\SIL.Media.targets')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.16.0.0-beta0061\build\SIL.Windows.Forms.Keyboarding.targets')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.16.0.0-beta0061\build\SIL.Windows.Forms.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/SayMoreTests/app.config
+++ b/src/SayMoreTests/app.config
@@ -75,15 +75,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SIL.Windows.Forms" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.2.0.0" newVersion="14.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SIL.WritingSystems" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.2.0.0" newVersion="14.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SIL.Core.Desktop" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.2.0.0" newVersion="14.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -123,7 +123,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SIL.Windows.Forms.Keyboarding" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.2.0.0" newVersion="14.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
@@ -144,6 +144,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.Archiving" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/SayMoreTests/packages.config
+++ b/src/SayMoreTests/packages.config
@@ -14,7 +14,8 @@
   <package id="ibusdotnet" version="2.0.3" targetFramework="net462" />
   <package id="icu.net" version="3.0.0" targetFramework="net462" />
   <package id="Instances" version="3.0.1" targetFramework="net462" />
-  <package id="L10NSharp" version="7.0.0" targetFramework="net462" />
+  <package id="KeymanLegacyBundle" version="1.0.0" targetFramework="net462" />
+  <package id="L10NSharp" version="8.0.0-beta0005" targetFramework="net462" />
   <package id="Markdig.Signed" version="0.37.0" targetFramework="net462" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.1" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net462" />
@@ -30,14 +31,14 @@
   <package id="NUnit.ConsoleRunner" version="3.19.0" targetFramework="net462" />
   <package id="NUnit3TestAdapter" version="4.6.0" targetFramework="net462" developmentDependency="true" />
   <package id="PangoSharp-signed" version="3.22.24.37" targetFramework="net462" />
-  <package id="SIL.Archiving" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Core" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Core.Desktop" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Media" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.TestUtilities" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Windows.Forms" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.Windows.Forms.Keyboarding" version="15.0.0" targetFramework="net462" />
-  <package id="SIL.WritingSystems" version="15.0.0" targetFramework="net462" />
+  <package id="SIL.Archiving" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Core" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Core.Desktop" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Media" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.TestUtilities" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Windows.Forms" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.Windows.Forms.Keyboarding" version="16.0.0-beta0061" targetFramework="net462" />
+  <package id="SIL.WritingSystems" version="16.0.0-beta0061" targetFramework="net462" />
   <package id="Spart" version="1.0.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.6.0" targetFramework="net462" />
   <package id="System.Configuration.ConfigurationManager" version="6.0.0" targetFramework="net462" />


### PR DESCRIPTION
Fixed order of initialization steps in ContributorsEditor to avoid crash Also, fixed another crash in SessionBasicEditor caused by calling non-threadsafe UI code on a non-UI thread. This is seemingly unrelated to this issue, but since it came up after making the other changes, it's possibly related in some way.