### PR TITLE
Changed AssemblyInfo.cs to be encoded as UTF-8

### DIFF
--- a/src/SayMore/Properties/AssemblyInfo.cs
+++ b/src/SayMore/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL Global")]
 [assembly: AssemblyProduct("SayMore")]
-[assembly: AssemblyCopyright("Copyright © 2011-2025 SIL Global")]
+[assembly: AssemblyCopyright("Copyright Â© 2011-2025 SIL Global")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
This gets the copyright symbol to render in the splash screen in the installed version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/216)
<!-- Reviewable:end -->
