### PR TITLE
SP-913: Stop playback of combined oral annotation audio when another file is chosen

### DIFF
--- a/src/SayMore/UI/ElementListScreen/ComponentFileGrid.cs
+++ b/src/SayMore/UI/ElementListScreen/ComponentFileGrid.cs
@@ -31,6 +31,8 @@ namespace SayMore.UI.ElementListScreen
 		/// <summary>When the user selects a different component (or no component is selected!), this is called</summary>
 		public Action<int> AfterComponentSelectionChanged;
 
+		public event EventHandler PrepareToSelectDifferentFile ;
+
 		/// <summary>
 		/// When the user chooses a menu command, this is called after the command is issued.
 		/// </summary>
@@ -388,6 +390,8 @@ namespace SayMore.UI.ElementListScreen
 		{
 			if (_handlingForceRefresh)
 				return;
+			
+			PrepareToSelectDifferentFile?.Invoke(this, EventArgs.Empty);
 
 			_handlingForceRefresh = true;
 			BuildMenuCommands(_grid.CurrentCellAddress.Y);

--- a/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
+++ b/src/SayMore/UI/ElementListScreen/ElementListScreen.cs
@@ -93,6 +93,7 @@ namespace SayMore.UI.ElementListScreen
 			_componentFilesControl.PostMenuCommandRefreshAction = HandlePostMenuCommandRefresh;
 			_componentFilesControl.IsOKToSelectDifferentFile = GetIsOKToLeaveCurrentEditor;
 			_componentFilesControl.IsOKToDoFileOperation = GetIsOKToLeaveCurrentEditor;
+			_componentFilesControl.PrepareToSelectDifferentFile += PrepareToSelectDifferentFile;
 
 			LoadElementList();
 		}
@@ -516,6 +517,8 @@ namespace SayMore.UI.ElementListScreen
 		protected virtual void HandleSelectedElementChanged(object sender,
 			ProjectElement oldItem, ProjectElement newItem)
 		{
+			PrepareToDeactivateCurrentEditor();
+			
 			_model.SetSelectedElement(newItem as T);
 			UpdateComponentFileList();
 		}
@@ -536,6 +539,12 @@ namespace SayMore.UI.ElementListScreen
 		/// ------------------------------------------------------------------------------------
 		public virtual void ViewDeactivated()
 		{
+			PrepareToDeactivateCurrentEditor();
+		}
+		
+		/// ------------------------------------------------------------------------------------
+		public virtual void PrepareToDeactivateCurrentEditor()
+		{
 			if (_selectedEditorsTabControl?.SelectedTab is ComponentEditorTabPage componentEditorTab)
 				componentEditorTab.EditorProvider?.PrepareToDeactivate();
 		}
@@ -554,6 +563,12 @@ namespace SayMore.UI.ElementListScreen
 
 			var editor = SelectedComponentEditorsTabControl.CurrentEditor;
 			return (editor == null || editor.IsOKToLeaveEditor);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		protected virtual void PrepareToSelectDifferentFile(object sender, EventArgs args)
+		{
+			SelectedComponentEditorsTabControl?.CurrentEditor?.PrepareToDeactivate();
 		}
 
 		/// <summary>


### PR DESCRIPTION
Added PrepareToSelectDifferentFile event in ComponentFileGrid so that subscribers can be alerted. In ElementListScreen, handled that event by informing current editor to prepare to deactivate. In the case of the OralAnnotationEditor, this allows it to stop playback in a timely fashion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/228)
<!-- Reviewable:end -->
