### PR TITLE
Added a label with instructions about importing flextext file into Flex

### DIFF
--- a/DistFiles/SayMore.es.xlf
+++ b/DistFiles/SayMore.es.xlf
@@ -2772,6 +2772,11 @@
         <target xml:lang="es-ES" state="translated">Habla cuidadosa</target>
         <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg._labelCarefulSpeech</note>
       </trans-unit>
+      <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg">
+        <source xml:lang="en">Sorry, we don't actually have a video for this yet. Contributions welcome!</source>
+        <target xml:lang="es-ES" state="translated">Lo sentimos, todavía no tenemos un video para esto. ¡Contribuciones bienvenidas!</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg</note>
+      </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.WindowTitle">
         <source xml:lang="en">Change this text</source>
         <target xml:lang="es-ES" state="needs-translation">Change this text</target>
@@ -2858,13 +2863,13 @@
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1">
-        <source xml:lang="en">In order to export, we need to find a writing system ID that FLEx will accept. SayMore tried to find a list of writing systems which FLEx knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="es-ES" state="translated">Para exportar se requiere un sistema de escritura que FLEx reconoce. SayMore intentó encontrar la lista de sistemas de escritura que FLEx reconoce buscándola en {0}, pero no existe. Recomendamos que use el código 'en' (inglés). A continuación usted lo puede cambiar dentro de FLEx.</target>
+        <source xml:lang="en">In order to export, we need to find a writing system ID that {1} will accept. {2} tried to find a list of writing systems which {1} knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of {1}.</source>
+        <target xml:lang="es-ES" state="translated">Para exportar se requiere un sistema de escritura que {1} reconoce. {2} intentó encontrar la lista de sistemas de escritura que {1} reconoce buscándola en {0}, pero no existe. Recomendamos que use el código 'en' (inglés). A continuación usted lo puede cambiar dentro de {1}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2">
-        <source xml:lang="en">SayMore was unable to find any Writing Systems on this computer. Make sure FLEx version 7.1 or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into FLEx.</source>
-        <target xml:lang="es-ES" state="translated">SayMore no pudo encontrar ningún sistema de escritura en este equipo. Hacer seguro FLEx versión 7.1 o superior instalado como se ha ejecutado al menos una vez. Por ahora, puede exportar como inglés y arreglar eso después de que haya importado en FLEx.</target>
+        <source xml:lang="en">{0} was unable to find any Writing Systems on this computer. Make sure {1} version {2} or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into {1}.</source>
+        <target xml:lang="es-ES" state="translated">{0} no pudo encontrar ningún sistema de escritura en este equipo. Asegúrese de que {1}, versión {2} o superior, esté instalado y se haya ejecutado al menos una vez. Por ahora, puede exportar en inglés y corregirlo después de importarlo en {1}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton">
@@ -2877,14 +2882,14 @@
         <target xml:lang="es-ES" state="translated">Exportar a archivo</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString">
-        <source xml:lang="en">FLEx Interlinear (*.flextext)|*.flextext|All Files (*.*)|*.*</source>
-        <target xml:lang="es-ES" state="translated">FLEx Interlineal (*.flextext)|*.flextext|Todos los archivos (*.*)|*.*</target>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString</note>
+      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc">
+        <source xml:lang="en">FLEx Interlinear ({0})</source>
+        <target xml:lang="es-ES" state="translated">FLEx Interlineal ({0})</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg">
-        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="es-ES" state="translated">Hubo un problema al inicializar el repositorio de los sistemas de escritura: "{0}". Se recomienda que deje que el código sea 'en' (inglés), luego cambiarlo dentro de FLEx.</target>
+        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</source>
+        <target xml:lang="es-ES" state="translated">Hubo un problema al inicializar el repositorio de sistemas de escritura: "{0}". Se recomienda dejar el código como '{1}' (inglés), y luego cambiarlo dentro de {2}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel">
@@ -3892,6 +3897,11 @@
         <target xml:lang="es-ES" state="translated">Ayuda para los protocolos de acceso</target>
         <note>ID: ProjectView.AccessScreen._linkHelp</note>
       </trans-unit>
+      <trans-unit id="ProjectView.AmbiguousDateNote">
+        <source xml:lang="en">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</source>
+        <target xml:lang="es-ES" state="translated">Una fecha ambigua ({0}) fue cargada, probablemente debido a un error en una versión anterior de {1}. Por favor, asegúrese de que se haya interpretado correctamente.</target>
+        <note>ID: ProjectView.AmbiguousDateNote</note>
+      </trans-unit>
       <trans-unit id="ProjectView.DescriptionDocuments._linkHowArchived">
         <source xml:lang="en">How these are archived</source>
         <target xml:lang="es-ES" state="translated">Cómo son archivadas</target>
@@ -4179,7 +4189,7 @@
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILCA.U" sil:dynamic="true">
         <source xml:lang="en">all Users can access (requires registration)</source>
-        <target xml:lang="es-ES" state="translated">Todos los usuarios pueden acceder (requiere registro)</target>
+        <target xml:lang="es-ES" state="translated">todos los usuarios pueden acceder (requiere registro)</target>
         <note>ID: SessionsView.MetadataEditor.AccessProtocol.AILCA.U</note>
       </trans-unit>
       <trans-unit id="SessionsView.MetadataEditor.AccessProtocol.AILLA.Level 1" sil:dynamic="true">

--- a/DistFiles/SayMore.fr.xlf
+++ b/DistFiles/SayMore.fr.xlf
@@ -2772,6 +2772,11 @@
         <target xml:lang="fr" state="translated">Discours soigneux</target>
         <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg._labelCarefulSpeech</note>
       </trans-unit>
+      <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg">
+        <source xml:lang="en">Sorry, we don't actually have a video for this yet. Contributions welcome!</source>
+        <target xml:lang="fr" state="needs-translation">Sorry, we don't actually have a video for this yet. Contributions welcome!</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg</note>
+      </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.WindowTitle">
         <source xml:lang="en">Change this text</source>
         <target xml:lang="fr" state="needs-translation">Change this text</target>
@@ -2858,12 +2863,12 @@
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1">
-        <source xml:lang="en">In order to export, we need to find a writing system ID that FLEx will accept. SayMore tried to find a list of writing systems which FLEx knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="fr" state="translated">Pour exporter, nous devons trouver un système d'écriture que FLEx acceptera. SayMore a essayé de trouver une liste des systèmes d'écriture que FLEx connaît en recherchant dans le dossier {0}, mais il n'existe pas. On vous conseille d'utiliser le code 'en' (anglais), puis le changer chez FLEx.</target>
+        <source xml:lang="en">In order to export, we need to find a writing system ID that {1} will accept. {2} tried to find a list of writing systems which {1} knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of {1}.</source>
+        <target xml:lang="fr" state="translated">Pour exporter, nous devons trouver un système d'écriture que {1} acceptera. {2} a essayé de trouver une liste des systèmes d'écriture que {1} connaît en recherchant dans le dossier {0}, mais il n'existe pas. On vous conseille d'utiliser le code 'en' (anglais), puis le changer chez {1}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2">
-        <source xml:lang="en">SayMore was unable to find any Writing Systems on this computer. Make sure FLEx version 7.1 or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into FLEx.</source>
+        <source xml:lang="en">{0} was unable to find any Writing Systems on this computer. Make sure {1} version {2} or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into {1}.</source>
         <target xml:lang="fr" state="translated">SayMore n'a pu trouver aucun système d'écriture sur cet ordinateur. Vérifier que FLEx (version 7.1 ou supérieure) est installé et qu'il a été lancé au moins une fois. Pour l'instant, vous pouvez exporter en tant qu'anglais et le changer après l'importation vers FLEx.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2</note>
       </trans-unit>
@@ -2877,14 +2882,14 @@
         <target xml:lang="fr" state="translated">Exporter vers fichier</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString">
-        <source xml:lang="en">FLEx Interlinear (*.flextext)|*.flextext|All Files (*.*)|*.*</source>
-        <target xml:lang="fr" state="translated">FLEx Interlinéaire (*.flextext)|*.flextext|Tous les fichiers (*.*)|*.*</target>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString</note>
+      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc">
+        <source xml:lang="en">FLEx Interlinear ({0})</source>
+        <target xml:lang="fr" state="translated">FLEx texte interlinéaire ({0})</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg">
-        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="fr" state="needs-translation">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</target>
+        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</source>
+        <target xml:lang="fr" state="needs-translation">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel">
@@ -3891,6 +3896,11 @@
         <source xml:lang="en">Help for access protocols</source>
         <target xml:lang="fr" state="translated">Aide sur les protocoles d'accès</target>
         <note>ID: ProjectView.AccessScreen._linkHelp</note>
+      </trans-unit>
+      <trans-unit id="ProjectView.AmbiguousDateNote">
+        <source xml:lang="en">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</source>
+        <target xml:lang="fr" state="needs-translation">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</target>
+        <note>ID: ProjectView.AmbiguousDateNote</note>
       </trans-unit>
       <trans-unit id="ProjectView.DescriptionDocuments._linkHowArchived">
         <source xml:lang="en">How these are archived</source>

--- a/DistFiles/SayMore.pt.xlf
+++ b/DistFiles/SayMore.pt.xlf
@@ -2762,6 +2762,11 @@
         <target xml:lang="pt-BR" state="translated">Fala Cuidadosa</target>
         <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg._labelCarefulSpeech</note>
       </trans-unit>
+      <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg">
+        <source xml:lang="en">Sorry, we don't actually have a video for this yet. Contributions welcome!</source>
+        <target xml:lang="pt-BR" state="needs-translation">Sorry, we don't actually have a video for this yet. Contributions welcome!</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg</note>
+      </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.WindowTitle">
         <source xml:lang="en">Change this text</source>
         <target xml:lang="pt-BR" state="translated">Mudar esse texto</target>
@@ -2848,13 +2853,13 @@
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1">
-        <source xml:lang="en">In order to export, we need to find a writing system ID that FLEx will accept. SayMore tried to find a list of writing systems which FLEx knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="pt-BR" state="translated">Para exportar, precisamos encontrar um código de sistema de escrita que o FLEx aceite. O SayMore tentou procurar em {0} uma lista de sistemas de escrita que o FLEx conhece, mas  não existe. Recomentamos que deixe o código 'en' (Inglês), e depois mude dentro do FLEx.</target>
+        <source xml:lang="en">In order to export, we need to find a writing system ID that {1} will accept. {2} tried to find a list of writing systems which {1} knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of {1}.</source>
+        <target xml:lang="pt-BR" state="translated">Para exportar, precisamos encontrar um código de sistema de escrita que o {1} aceite. O {2} tentou procurar em {0} uma lista de sistemas de escrita que o {1} conhece, mas não existe. Recomentamos que deixe o código 'en' (inglês), e depois mude dentro do {1}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2">
-        <source xml:lang="en">SayMore was unable to find any Writing Systems on this computer. Make sure FLEx version 7.1 or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into FLEx.</source>
-        <target xml:lang="pt-BR" state="translated">O SayMore não conseguiu encontrar nenhum Sistema de Escrita neste computador. Verifique se o FLEx 7.1 ou uma versão mais atualizada foi instalada e executada pelo menos uma vez. Por enquanto, você pode exportar como inglês e mudar isso depois que tiver importado para o FLEx.</target>
+        <source xml:lang="en">{0} was unable to find any Writing Systems on this computer. Make sure {1} version {2} or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into {1}.</source>
+        <target xml:lang="pt-BR" state="translated">O {0} não conseguiu encontrar nenhum Sistema de Escrita neste computador. Verifique se o {1} {2} ou uma versão mais atualizada foi instalada e executada pelo menos uma vez. Por enquanto, você pode exportar como inglês e mudar isso depois que tiver importado para o {1}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton">
@@ -2867,14 +2872,14 @@
         <target xml:lang="pt-BR" state="translated">Exportar Arquivo</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString">
-        <source xml:lang="en">FLEx Interlinear (*.flextext)|*.flextext|All Files (*.*)|*.*</source>
-        <target xml:lang="pt-BR" state="translated">FLEx Interlinear (*flextext)|*flextext|All Files (*.*)|*.*</target>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString</note>
+      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc">
+        <source xml:lang="en">FLEx Interlinear ({0})</source>
+        <target xml:lang="pt-BR" state="translated">Texto Interlinear FLEx ({0})</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg">
-        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="pt-BR" state="needs-translation">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</target>
+        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</source>
+        <target xml:lang="pt-BR" state="needs-translation">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel">
@@ -3881,6 +3886,11 @@
         <source xml:lang="en">Help for access protocols</source>
         <target xml:lang="pt-BR" state="translated">Ajuda para acessar protocolos</target>
         <note>ID: ProjectView.AccessScreen._linkHelp</note>
+      </trans-unit>
+      <trans-unit id="ProjectView.AmbiguousDateNote">
+        <source xml:lang="en">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</source>
+        <target xml:lang="pt-BR" state="needs-translation">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</target>
+        <note>ID: ProjectView.AmbiguousDateNote</note>
       </trans-unit>
       <trans-unit id="ProjectView.DescriptionDocuments._linkHowArchived">
         <source xml:lang="en">How these are archived</source>

--- a/DistFiles/SayMore.ru.xlf
+++ b/DistFiles/SayMore.ru.xlf
@@ -2766,6 +2766,11 @@ A или запись согласия covering
         <target xml:lang="ru" state="translated">Аккуратная речь</target>
         <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg._labelCarefulSpeech</note>
       </trans-unit>
+      <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg">
+        <source xml:lang="en">Sorry, we don't actually have a video for this yet. Contributions welcome!</source>
+        <target xml:lang="ru" state="needs-translation">Sorry, we don't actually have a video for this yet. Contributions welcome!</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg</note>
+      </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.WindowTitle">
         <source xml:lang="en">Change this text</source>
         <target xml:lang="ru" state="translated">Изменить этот текст</target>
@@ -2852,13 +2857,13 @@ A или запись согласия covering
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1">
-        <source xml:lang="en">In order to export, we need to find a writing system ID that FLEx will accept. SayMore tried to find a list of writing systems which FLEx knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="ru" state="translated">Для того чтобы экспортировать, нам необходимо найти идентификатор языка, который принимает программа FLEx. SayMore пытался найти список идентификаторов языка программы FLEx посмотрев в {0}, но они не существуют. Мы рекомендуем чтобы Вы использовали идентификатор 'en' (английский), и потом изменили его в установках программы FLEx.</target>
+        <source xml:lang="en">In order to export, we need to find a writing system ID that {1} will accept. {2} tried to find a list of writing systems which {1} knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of {1}.</source>
+        <target xml:lang="ru" state="translated">Для того чтобы экспортировать, нам необходимо найти идентификатор языка, который принимает программа {1}. {2} пытался найти список идентификаторов языка программы {1} посмотрев в {0}, но они не существуют. Мы рекомендуем чтобы Вы использовали идентификатор 'en' (английский), и потом изменили его в установках программы {1}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2">
-        <source xml:lang="en">SayMore was unable to find any Writing Systems on this computer. Make sure FLEx version 7.1 or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into FLEx.</source>
-        <target xml:lang="ru" state="translated">SayMore не удалось найти каких-либо идентификаторов языка на этом компьютере. Убедитесь что установлен FLEx версии 7.1 или выше и он был запущен хотябы один раз. В настоящее время можно экспортировать как английский и потом исправить это в установках FLEx.</target>
+        <source xml:lang="en">{0} was unable to find any Writing Systems on this computer. Make sure {1} version {2} or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into {1}.</source>
+        <target xml:lang="ru" state="translated">{0} не удалось найти каких-либо идентификаторов языка на этом компьютере. Убедитесь что установлен {1} версии {2} или выше и он был запущен хотябы один раз. В настоящее время можно экспортировать как английский и потом исправить это в установках {1}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton">
@@ -2871,14 +2876,14 @@ A или запись согласия covering
         <target xml:lang="ru" state="translated">Экспорт в файл</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString">
-        <source xml:lang="en">FLEx Interlinear (*.flextext)|*.flextext|All Files (*.*)|*.*</source>
-        <target xml:lang="ru" state="translated">FLEx Interlinear XML (*.xml)|*.xml|Все файлы (*.*)|*.*</target>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString</note>
+      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc">
+        <source xml:lang="en">FLEx Interlinear ({0})</source>
+        <target xml:lang="ru" state="translated">Текст FLEx Interlinear ({0})</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg">
-        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="ru" state="needs-translation">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</target>
+        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</source>
+        <target xml:lang="ru" state="needs-translation">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel">
@@ -3885,6 +3890,11 @@ A или запись согласия covering
         <source xml:lang="en">Help for access protocols</source>
         <target xml:lang="ru" state="translated">Помощь для протоколов доступа</target>
         <note>ID: ProjectView.AccessScreen._linkHelp</note>
+      </trans-unit>
+      <trans-unit id="ProjectView.AmbiguousDateNote">
+        <source xml:lang="en">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</source>
+        <target xml:lang="ru" state="needs-translation">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</target>
+        <note>ID: ProjectView.AmbiguousDateNote</note>
       </trans-unit>
       <trans-unit id="ProjectView.DescriptionDocuments._linkHowArchived">
         <source xml:lang="en">How these are archived</source>

--- a/DistFiles/SayMore.tr.xlf
+++ b/DistFiles/SayMore.tr.xlf
@@ -2773,6 +2773,11 @@ Avrupa</target>
         <target xml:lang="tr" state="translated">Dikkatli konuşma</target>
         <note>ID: DialogBoxes.Transcription.CarefulSpeechRecorderDlg._labelCarefulSpeech</note>
       </trans-unit>
+      <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg">
+        <source xml:lang="en">Sorry, we don't actually have a video for this yet. Contributions welcome!</source>
+        <target xml:lang="tr" state="needs-translation">Sorry, we don't actually have a video for this yet. Contributions welcome!</target>
+        <note>ID: DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.NoVideoHelpMsg</note>
+      </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.CommonAnnotationSegmenterDlg.WindowTitle">
         <source xml:lang="en">Change this text</source>
         <target xml:lang="tr" state="translated">Change this text</target>
@@ -2859,13 +2864,13 @@ Avrupa</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1">
-        <source xml:lang="en">In order to export, we need to find a writing system ID that FLEx will accept. SayMore tried to find a list of writing systems which FLEx knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="tr" state="translated">Dışa aktarabilmek için, FLEx'in kabul edebileceği bir yazı sistemi kimliği bulmalıyız. SayMore, {0}'a bakarak FLEx'in bildiği yazım sistemlerinin bir listesini bulmaya çalıştı, ancak bulamadı. Kodun 'en' (İngilizce) olmasına dikkat edin ve daha sonra FLEx'in içinde değiştirin.</target>
+        <source xml:lang="en">In order to export, we need to find a writing system ID that {1} will accept. {2} tried to find a list of writing systems which {1} knows about by looking in {0}, but it doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of {1}.</source>
+        <target xml:lang="tr" state="translated">Dışa aktarabilmek için, {1}'in kabul edebileceği bir yazı sistemi kimliği bulmalıyız. {2}, {0}'a bakarak {1}'in bildiği yazım sistemlerinin bir listesini bulmaya çalıştı, ancak bulamadı. Kodun 'en' (İngilizce) olmasına dikkat edin ve daha sonra {1}'in içinde değiştirin.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2">
-        <source xml:lang="en">SayMore was unable to find any Writing Systems on this computer. Make sure FLEx version 7.1 or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into FLEx.</source>
-        <target xml:lang="tr" state="translated">SayMore bu bilgisayarda herhangi bir Yazı Sistemi bulamadı. FLEx 7.1 veya üstü sürümlerinin kurulu olduğundan ve en az bir kez çalıştırıldığından emin olun. Şimdilik, İngilizce olarak dışa aktarabilir ve FLEx'e aktardıktan sonra bunu düzeltebilirsiniz.</target>
+        <source xml:lang="en">{0} was unable to find any Writing Systems on this computer. Make sure {1} version {2} or greater is installed and has been run at least once. For now, you can export as English, and fix that up after you have imported into {1}.</source>
+        <target xml:lang="tr" state="translated">{0} bu bilgisayarda herhangi bir Yazı Sistemi bulamadı. {1} {2} veya üstü sürümlerinin kurulu olduğundan ve en az bir kez çalıştırıldığından emin olun. Şimdilik, İngilizce olarak dışa aktarabilir ve {1}'e aktardıktan sonra bunu düzeltebilirsiniz.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton">
@@ -2878,14 +2883,14 @@ Avrupa</target>
         <target xml:lang="tr" state="translated">Dosyaya Aktar</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString">
-        <source xml:lang="en">FLEx Interlinear (*.flextext)|*.flextext|All Files (*.*)|*.*</source>
-        <target xml:lang="tr" state="translated">FLEx Satırarası (*.flextext)|*.flextext|Tüm Dosyalar (*.*)|*.*</target>
-        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString</note>
+      <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc">
+        <source xml:lang="en">FLEx Interlinear ({0})</source>
+        <target xml:lang="tr" state="translated">FLEx Satırarası Metin ({0})</target>
+        <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg">
-        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</source>
-        <target xml:lang="tr" state="needs-translation">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be 'en' (English), then change it inside of FLEx.</target>
+        <source xml:lang="en">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</source>
+        <target xml:lang="tr" state="needs-translation">There was a problem initializing the Writing System Repository: "{0}".We recommend that you let the code be '{1}' (English), then change it inside of {2}.</target>
         <note>ID: DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg</note>
       </trans-unit>
       <trans-unit id="DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel">
@@ -3892,6 +3897,11 @@ Avrupa</target>
         <source xml:lang="en">Help for access protocols</source>
         <target xml:lang="tr" state="translated">Erişim protokolleri için yardım</target>
         <note>ID: ProjectView.AccessScreen._linkHelp</note>
+      </trans-unit>
+      <trans-unit id="ProjectView.AmbiguousDateNote">
+        <source xml:lang="en">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</source>
+        <target xml:lang="tr" state="needs-translation">An ambiguous date ({0}) was loaded, probably produced by a bug in an old version of {1}. Please ensure the date was interpreted correctly.</target>
+        <note>ID: ProjectView.AmbiguousDateNote</note>
       </trans-unit>
       <trans-unit id="ProjectView.DescriptionDocuments._linkHowArchived">
         <source xml:lang="en">How these are archived</source>

--- a/DistFiles/releaseNotes.md
+++ b/DistFiles/releaseNotes.md
@@ -1,4 +1,7 @@
 ## _VERSION_ (_DATE_)
+* Small improvement in the logic to guess at the correct initial writing system for translations when exporting FLEx Interlinear files (flextext).
+
+## 3.7.3 (16 July 2025)
 * Allowed for manual addition of session files that the user created in the session folder with SayMore running.
 
 3.7.2 (23 May 2025)

--- a/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.Designer.cs
+++ b/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.Designer.cs
@@ -195,7 +195,6 @@ namespace SayMore.Transcription.UI
             this.locExtender.SetLocalizableToolTip(this._labelImportInstructions, null);
             this.locExtender.SetLocalizationComment(this._labelImportInstructions, "Param 0: FLEx (product name); Param 1: Writing system name (and BCP-47 identifier" +
         ")");
-            this.locExtender.SetLocalizationPriority(this._labelImportInstructions, L10NSharp.LocalizationPriority.NotLocalizable);
             this.locExtender.SetLocalizingId(this._labelImportInstructions, "ExportToFieldWorksInterlinearDlg._labelImportInstructions");
             this._labelImportInstructions.Location = new System.Drawing.Point(0, 98);
             this._labelImportInstructions.Margin = new System.Windows.Forms.Padding(0);

--- a/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.Designer.cs
+++ b/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.Designer.cs
@@ -1,3 +1,6 @@
+using L10NSharp.UI;
+using L10NSharp.XLiffUtils;
+
 namespace SayMore.Transcription.UI
 {
 	partial class ExportToFieldWorksInterlinearDlg
@@ -16,6 +19,8 @@ namespace SayMore.Transcription.UI
 			if (disposing && (components != null))
 			{
 				components.Dispose();
+				
+				LocalizeItemDlg<XLiffDocument>.StringsLocalized -= HandleStringsLocalized;
 			}
 			base.Dispose(disposing);
 		}
@@ -37,6 +42,7 @@ namespace SayMore.Transcription.UI
             this._labelFreeTranslationColumnHeadingText = new System.Windows.Forms.Label();
             this._comboTranslationWs = new System.Windows.Forms.ComboBox();
             this._labelOverview = new System.Windows.Forms.Label();
+            this._labelImportInstructions = new System.Windows.Forms.Label();
             this.locExtender = new L10NSharp.UI.L10NSharpExtender(this.components);
             this._tableLayout.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.locExtender)).BeginInit();
@@ -44,29 +50,31 @@ namespace SayMore.Transcription.UI
             // 
             // _tableLayout
             // 
-            this._tableLayout.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this._tableLayout.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this._tableLayout.AutoSize = true;
             this._tableLayout.ColumnCount = 4;
             this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this._tableLayout.Controls.Add(this._buttonCancel, 3, 3);
-            this._tableLayout.Controls.Add(this._buttonExport, 2, 3);
+            this._tableLayout.Controls.Add(this._buttonCancel, 3, 4);
+            this._tableLayout.Controls.Add(this._buttonExport, 2, 4);
             this._tableLayout.Controls.Add(this._labelTranscriptionColumnHeadingText, 0, 1);
             this._tableLayout.Controls.Add(this._comboTranscriptionWs, 1, 1);
             this._tableLayout.Controls.Add(this._labelFreeTranslationColumnHeadingText, 0, 2);
             this._tableLayout.Controls.Add(this._comboTranslationWs, 1, 2);
             this._tableLayout.Controls.Add(this._labelOverview, 0, 0);
+            this._tableLayout.Controls.Add(this._labelImportInstructions, 0, 3);
             this._tableLayout.Location = new System.Drawing.Point(18, 18);
             this._tableLayout.Name = "_tableLayout";
-            this._tableLayout.RowCount = 4;
+            this._tableLayout.RowCount = 5;
             this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this._tableLayout.Size = new System.Drawing.Size(284, 136);
+            this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this._tableLayout.Size = new System.Drawing.Size(284, 182);
             this._tableLayout.TabIndex = 0;
             // 
             // _buttonCancel
@@ -76,8 +84,8 @@ namespace SayMore.Transcription.UI
             this._buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.locExtender.SetLocalizableToolTip(this._buttonCancel, null);
             this.locExtender.SetLocalizationComment(this._buttonCancel, null);
-			this.locExtender.SetLocalizingId(this._buttonCancel, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton");
-            this._buttonCancel.Location = new System.Drawing.Point(209, 110);
+            this.locExtender.SetLocalizingId(this._buttonCancel, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CancelButton");
+            this._buttonCancel.Location = new System.Drawing.Point(209, 156);
             this._buttonCancel.Margin = new System.Windows.Forms.Padding(4, 12, 0, 0);
             this._buttonCancel.Name = "_buttonCancel";
             this._buttonCancel.Size = new System.Drawing.Size(75, 26);
@@ -91,8 +99,8 @@ namespace SayMore.Transcription.UI
             this._buttonExport.AutoSize = true;
             this.locExtender.SetLocalizableToolTip(this._buttonExport, null);
             this.locExtender.SetLocalizationComment(this._buttonExport, null);
-			this.locExtender.SetLocalizingId(this._buttonExport, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton");
-            this._buttonExport.Location = new System.Drawing.Point(126, 110);
+            this.locExtender.SetLocalizingId(this._buttonExport, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportButton");
+            this._buttonExport.Location = new System.Drawing.Point(126, 156);
             this._buttonExport.Margin = new System.Windows.Forms.Padding(0, 12, 4, 0);
             this._buttonExport.Name = "_buttonExport";
             this._buttonExport.Size = new System.Drawing.Size(75, 26);
@@ -107,7 +115,7 @@ namespace SayMore.Transcription.UI
             this._labelTranscriptionColumnHeadingText.AutoSize = true;
             this.locExtender.SetLocalizableToolTip(this._labelTranscriptionColumnHeadingText, null);
             this.locExtender.SetLocalizationComment(this._labelTranscriptionColumnHeadingText, null);
-			this.locExtender.SetLocalizingId(this._labelTranscriptionColumnHeadingText, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.TranscriptionLabel");
+            this.locExtender.SetLocalizingId(this._labelTranscriptionColumnHeadingText, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.TranscriptionLabel");
             this._labelTranscriptionColumnHeadingText.Location = new System.Drawing.Point(0, 45);
             this._labelTranscriptionColumnHeadingText.Margin = new System.Windows.Forms.Padding(0);
             this._labelTranscriptionColumnHeadingText.Name = "_labelTranscriptionColumnHeadingText";
@@ -124,7 +132,7 @@ namespace SayMore.Transcription.UI
             this.locExtender.SetLocalizableToolTip(this._comboTranscriptionWs, null);
             this.locExtender.SetLocalizationComment(this._comboTranscriptionWs, null);
             this.locExtender.SetLocalizationPriority(this._comboTranscriptionWs, L10NSharp.LocalizationPriority.NotLocalizable);
-			this.locExtender.SetLocalizingId(this._comboTranscriptionWs, "_comboTranscriptionWs");
+            this.locExtender.SetLocalizingId(this._comboTranscriptionWs, "_comboTranscriptionWs");
             this._comboTranscriptionWs.Location = new System.Drawing.Point(27, 41);
             this._comboTranscriptionWs.Margin = new System.Windows.Forms.Padding(3, 5, 0, 5);
             this._comboTranscriptionWs.Name = "_comboTranscriptionWs";
@@ -138,7 +146,7 @@ namespace SayMore.Transcription.UI
             this._labelFreeTranslationColumnHeadingText.AutoSize = true;
             this.locExtender.SetLocalizableToolTip(this._labelFreeTranslationColumnHeadingText, null);
             this.locExtender.SetLocalizationComment(this._labelFreeTranslationColumnHeadingText, null);
-			this.locExtender.SetLocalizingId(this._labelFreeTranslationColumnHeadingText, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel");
+            this.locExtender.SetLocalizingId(this._labelFreeTranslationColumnHeadingText, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FreeTranslationLabel");
             this._labelFreeTranslationColumnHeadingText.Location = new System.Drawing.Point(0, 76);
             this._labelFreeTranslationColumnHeadingText.Margin = new System.Windows.Forms.Padding(0);
             this._labelFreeTranslationColumnHeadingText.Name = "_labelFreeTranslationColumnHeadingText";
@@ -155,23 +163,24 @@ namespace SayMore.Transcription.UI
             this.locExtender.SetLocalizableToolTip(this._comboTranslationWs, null);
             this.locExtender.SetLocalizationComment(this._comboTranslationWs, null);
             this.locExtender.SetLocalizationPriority(this._comboTranslationWs, L10NSharp.LocalizationPriority.NotLocalizable);
-			this.locExtender.SetLocalizingId(this._comboTranslationWs, "_comboTranslationWs");
+            this.locExtender.SetLocalizingId(this._comboTranslationWs, "_comboTranslationWs");
             this._comboTranslationWs.Location = new System.Drawing.Point(27, 72);
             this._comboTranslationWs.Margin = new System.Windows.Forms.Padding(3, 5, 0, 5);
             this._comboTranslationWs.Name = "_comboTranslationWs";
             this._comboTranslationWs.Size = new System.Drawing.Size(257, 21);
             this._comboTranslationWs.TabIndex = 6;
+            this._comboTranslationWs.SelectedIndexChanged += new System.EventHandler(this._comboTranslationWs_SelectedIndexChanged);
             this._comboTranslationWs.SelectionChangeCommitted += new System.EventHandler(this.HandleWritingSystemChanged);
             // 
             // _labelOverview
             // 
-            this._labelOverview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this._labelOverview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this._labelOverview.AutoSize = true;
             this._tableLayout.SetColumnSpan(this._labelOverview, 4);
             this.locExtender.SetLocalizableToolTip(this._labelOverview, null);
             this.locExtender.SetLocalizationComment(this._labelOverview, null);
-			this.locExtender.SetLocalizingId(this._labelOverview, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.OverviewLabel");
+            this.locExtender.SetLocalizingId(this._labelOverview, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.OverviewLabel");
             this._labelOverview.Location = new System.Drawing.Point(0, 0);
             this._labelOverview.Margin = new System.Windows.Forms.Padding(0, 0, 0, 10);
             this._labelOverview.Name = "_labelOverview";
@@ -179,9 +188,28 @@ namespace SayMore.Transcription.UI
             this._labelOverview.TabIndex = 7;
             this._labelOverview.Text = "Specify the writing systems for the transcriptions and free translations.";
             // 
+            // _labelImportInstructions
+            // 
+            this._labelImportInstructions.AutoSize = true;
+            this._tableLayout.SetColumnSpan(this._labelImportInstructions, 4);
+            this.locExtender.SetLocalizableToolTip(this._labelImportInstructions, null);
+            this.locExtender.SetLocalizationComment(this._labelImportInstructions, "Param 0: FLEx (product name); Param 1: Writing system name (and BCP-47 identifier" +
+        ")");
+            this.locExtender.SetLocalizationPriority(this._labelImportInstructions, L10NSharp.LocalizationPriority.NotLocalizable);
+            this.locExtender.SetLocalizingId(this._labelImportInstructions, "ExportToFieldWorksInterlinearDlg._labelImportInstructions");
+            this._labelImportInstructions.Location = new System.Drawing.Point(0, 98);
+            this._labelImportInstructions.Margin = new System.Windows.Forms.Padding(0);
+            this._labelImportInstructions.Name = "_labelImportInstructions";
+            this._labelImportInstructions.Padding = new System.Windows.Forms.Padding(0, 10, 0, 10);
+            this._labelImportInstructions.Size = new System.Drawing.Size(254, 46);
+            this._labelImportInstructions.TabIndex = 8;
+            this._labelImportInstructions.Text = "When importing this file into {0}, be sure to have the project anlysis language s" +
+    "et to {1} .";
+            // 
             // locExtender
             // 
             this.locExtender.LocalizationManagerId = "SayMore";
+            this.locExtender.PrefixForNewItems = null;
             // 
             // ExportToFieldWorksInterlinearDlg
             // 
@@ -189,12 +217,12 @@ namespace SayMore.Transcription.UI
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.CancelButton = this._buttonCancel;
-            this.ClientSize = new System.Drawing.Size(320, 146);
+            this.ClientSize = new System.Drawing.Size(320, 186);
             this.Controls.Add(this._tableLayout);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.locExtender.SetLocalizableToolTip(this, null);
             this.locExtender.SetLocalizationComment(this, null);
-			this.locExtender.SetLocalizingId(this, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.WindowTitle");
+            this.locExtender.SetLocalizingId(this, "DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.WindowTitle");
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "ExportToFieldWorksInterlinearDlg";
@@ -223,5 +251,6 @@ namespace SayMore.Transcription.UI
 		private System.Windows.Forms.ComboBox _comboTranslationWs;
 		private System.Windows.Forms.Label _labelOverview;
 		private L10NSharp.UI.L10NSharpExtender locExtender;
+		private System.Windows.Forms.Label _labelImportInstructions;
 	}
 }

--- a/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.cs
+++ b/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.cs
@@ -1,17 +1,24 @@
+using L10NSharp;
+using L10NSharp.UI;
+using L10NSharp.XLiffUtils;
+using SayMore.Properties;
+using SIL.Reporting;
+using SIL.WritingSystems;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
-using L10NSharp;
-using SIL.Reporting;
-using SIL.WritingSystems;
-using SayMore.Properties;
+using static SayMore.Utilities.FileSystemUtils;
+using static System.String;
 
 namespace SayMore.Transcription.UI
 {
 	public partial class ExportToFieldWorksInterlinearDlg : Form
 	{
+		private const string kFlexTextExt = ".flextext";
+		private const string kFlexProgramName = "FLEx";
+
 		#region DisplayFriendlyWritingSystem class
 		/// ------------------------------------------------------------------------------------
 		public class DisplayFriendlyWritingSystem
@@ -19,14 +26,13 @@ namespace SayMore.Transcription.UI
 			public string Id;
 			public string Name;
 
-			public override string ToString()
-			{
-				return string.Format("{0} ({1})", Name, Id);
-			}
+			public override string ToString() => $"{Name} ({Id})";
 		}
 
 		#endregion
 
+		private string _intructionsFmt;
+		
 		public string FileName { get; private set; }
 		public DisplayFriendlyWritingSystem TranscriptionWs { get; private set; }
 		public DisplayFriendlyWritingSystem FreeTranslationWs { get; private set; }
@@ -34,7 +40,7 @@ namespace SayMore.Transcription.UI
 		/// ------------------------------------------------------------------------------------
 		public ExportToFieldWorksInterlinearDlg(string defaultExportFileName) : this()
 		{
-			FileName = defaultExportFileName + ".flextext";
+			FileName = defaultExportFileName + kFlexTextExt;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -44,10 +50,10 @@ namespace SayMore.Transcription.UI
 			InitializeComponent();
 
 			_labelTranscriptionColumnHeadingText.Text =
-				string.Format(_labelTranscriptionColumnHeadingText.Text, CommonUIStrings.TranscriptionTierDisplayName);
+				Format(_labelTranscriptionColumnHeadingText.Text, CommonUIStrings.TranscriptionTierDisplayName);
 
 			_labelFreeTranslationColumnHeadingText.Text =
-				string.Format(_labelFreeTranslationColumnHeadingText.Text, CommonUIStrings.TranslationTierDisplayName);
+				Format(_labelFreeTranslationColumnHeadingText.Text, CommonUIStrings.TranslationTierDisplayName);
 
 			_labelOverview.Font = Program.DialogFont;
 			_labelTranscriptionColumnHeadingText.Font = Program.DialogFont;
@@ -55,10 +61,32 @@ namespace SayMore.Transcription.UI
 			_comboTranscriptionWs.Font = Program.DialogFont;
 			_comboTranslationWs.Font = Program.DialogFont;
 
+			HandleStringsLocalized();
+			LocalizeItemDlg<XLiffDocument>.StringsLocalized += HandleStringsLocalized;
 		}
 
 		/// ------------------------------------------------------------------------------------
-		private IEnumerable<WritingSystemDefinition> GetAvailableWritingSystems()
+		protected void HandleStringsLocalized(ILocalizationManager lm = null)
+		{
+			if (lm == null || lm.Id == ApplicationContainer.kSayMoreLocalizationId)
+			{
+				_intructionsFmt = _labelImportInstructions.Text;
+				FormatImportInstructions();
+			}
+		}
+
+		/// ------------------------------------------------------------------------------------
+		private void FormatImportInstructions()
+		{
+			if (_comboTranslationWs.SelectedIndex >= 0)
+			{
+				_labelImportInstructions.Text = Format(_intructionsFmt, kFlexProgramName,
+					(DisplayFriendlyWritingSystem)_comboTranslationWs.SelectedItem);
+			}
+		}
+
+		/// ------------------------------------------------------------------------------------
+		private static IEnumerable<WritingSystemDefinition> GetAvailableWritingSystems()
 		{
 			// FLEx 9 uses C:\ProgramData\SIL\WritingSystemRepository
 			var repoPath = Path.Combine(Program.SilCommonDataFolder, "WritingSystemRepository");
@@ -74,12 +102,12 @@ namespace SayMore.Transcription.UI
 			{
 				var msg = LocalizationManager.GetString(
 					"DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg1",
-					"In order to export, we need to find a writing system ID that FLEx will accept. SayMore " +
-					"tried to find a list of writing systems which FLEx knows about by looking in {0}, but it " +
-					"doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of FLEx.",
-					"The parameter is a folder path");
+					"In order to export, we need to find a writing system ID that {1} will accept. {2} " +
+					"tried to find a list of writing systems which {1} knows about by looking in {0}, but it " +
+					"doesn't exist. We recommend that you let the code be 'en' (English), then change it inside of {1}.",
+					"Param 0: folder path; Param 1: \"FLEx\" (product name); Param 2: \"SayMore\" (product name)");
 
-				ErrorReport.NotifyUserOfProblem(msg, globalPath);
+				ErrorReport.NotifyUserOfProblem(msg, globalPath, kFlexProgramName, Program.ProductName);
 				return new[] {new WritingSystemDefinition("en")};
 			}
 
@@ -93,10 +121,10 @@ namespace SayMore.Transcription.UI
 				var msg = LocalizationManager.GetString(
 					"DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.FLExWritingSystemRepositoryMsg",
 					"There was a problem initializing the Writing System Repository: \"{0}\"." +
-					"We recommend that you let the code be 'en' (English), then change it inside of FLEx.",
-					"The parameter is an error message");
+					"We recommend that you let the code be '{1}' (English), then change it inside of {2}.",
+					"Param 0: error message; Param 1: \"en\" (writing system locale); Param 2: \"FLEx\" (product name)");
 
-				ErrorReport.NotifyUserOfProblem(msg, ex.Message);
+				ErrorReport.NotifyUserOfProblem(msg, ex.Message, kFlexProgramName);
 				return new[] {new WritingSystemDefinition("en")};
 			}
 		}
@@ -109,12 +137,28 @@ namespace SayMore.Transcription.UI
 		}
 
 		/// ------------------------------------------------------------------------------------
-		private void IntializeWritingSystemCombo(ComboBox combo, string initialWs)
+		/// <summary>Select the desired writing system in the given combo.</summary>
+		/// <param name="combo">The writing system combo box (whose items are expected to be of
+		/// type <see cref="DisplayFriendlyWritingSystem"/>.</param>
+		/// <param name="initialWss">An array of BCP-47 writing system locale identifiers. If more
+		/// than one is provided, they should be given in order of descending preference; the first
+		/// one that corresponds to an existing writing system in the combo box will be selected.
+		/// </param>
+		/// ------------------------------------------------------------------------------------
+		private static void InitializeWritingSystemCombo(ComboBox combo, params string[] initialWss)
 		{
-			if (initialWs != null)
+			if (initialWss != null)
 			{
-				combo.SelectedItem =
-					combo.Items.Cast<DisplayFriendlyWritingSystem>().FirstOrDefault(w => w.Id == initialWs);
+				foreach (var initialWs in initialWss)
+				{
+					var itemToSelect = combo.Items.Cast<DisplayFriendlyWritingSystem>()
+						.FirstOrDefault(w => w.Id == initialWs);
+					if (itemToSelect != null)
+					{
+						combo.SelectedItem = itemToSelect;
+						return;
+					}
+				}
 			}
 
 			if (combo.SelectedItem == null)
@@ -131,9 +175,15 @@ namespace SayMore.Transcription.UI
 					"DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.Caption",
 					"Export to File");
 
-				dlg.Filter = LocalizationManager.GetString(
-					"DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.FileTypeString",
-					"FLEx Interlinear (*.flextext)|*.flextext|All Files (*.*)|*.*");
+				var flexInterlinearFilesDesc = LocalizationManager.GetString(
+					"DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.ExportSaveFileDlg.InterlinearFilesDesc",
+					"FLEx Interlinear ({0})", "Parameter is a file-matching pattern: \"*.flextext\"");
+
+				dlg.Filter = Format("{0}|{1}|{2}|{3}",
+					Format(flexInterlinearFilesDesc, "*" + kFlexTextExt),
+					"*" + kFlexTextExt,
+					Format(LocalizedVersionOfAllFilesDescriptor, kAllFilesFilter),
+					kAllFilesFilter);
 
 				dlg.FileName = FileName;
 				dlg.OverwritePrompt = true;
@@ -173,9 +223,10 @@ namespace SayMore.Transcription.UI
 		/// ------------------------------------------------------------------------------------
 		private void UpdateDisplay()
 		{
-			_buttonExport.Enabled = (TranscriptionWs != null && FreeTranslationWs != null);
+			_buttonExport.Enabled = TranscriptionWs != null && FreeTranslationWs != null;
 		}
 
+		/// ------------------------------------------------------------------------------------
 		private void ExportToFieldWorksInterlinearDlg_Load(object sender, EventArgs e)
 		{
 			var wsList = GetAvailableWritingSystems()
@@ -183,12 +234,17 @@ namespace SayMore.Transcription.UI
 
 			if (wsList.Length == 0)
 			{
-				var msg = LocalizationManager.GetString("DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2",
-					"SayMore was unable to find any Writing Systems on this computer. Make sure FLEx version 7.1 or greater is " +
-					"installed and has been run at least once. For now, you can export as English, and fix that up after you " +
-					"have imported into FLEx.");
+				var msg = LocalizationManager.GetString(
+					"DialogBoxes.Transcription.ExportToFieldWorksInterlinearDlg.CannotFindFLExWritingSystemsMsg2",
+					"{0} was unable to find any Writing Systems on this computer. Make sure {1} " +
+					"version {2} or greater is installed and has been run at least once. " +
+					"For now, you can export as English, and fix that up after you have " +
+					"imported into {1}.",
+					"Param 0: \"SayMore\" (product name); " +
+					"Param 1: \"FLEx\" (product name); " +
+					"Param 2: minimum supported FLEx version number");
 
-				ErrorReport.NotifyUserOfProblem(msg);
+				ErrorReport.NotifyUserOfProblem(msg, Program.ProductName, kFlexProgramName, "7.1");
 				wsList = new DisplayFriendlyWritingSystem[1];
 				wsList[0] = new DisplayFriendlyWritingSystem { Id = "en", Name = "English" };
 			}
@@ -196,14 +252,29 @@ namespace SayMore.Transcription.UI
 			_comboTranscriptionWs.Items.AddRange(wsList);
 			_comboTranslationWs.Items.AddRange(wsList);
 
-			IntializeWritingSystemCombo(_comboTranscriptionWs,
+			InitializeWritingSystemCombo(_comboTranscriptionWs,
 				Settings.Default.TranscriptionWsForFWInterlinearExport);
 
-			IntializeWritingSystemCombo(_comboTranslationWs,
-				string.IsNullOrEmpty(Settings.Default.FreeTranslationWsForFWInterlinearExport) ? "en" :
-				Settings.Default.FreeTranslationWsForFWInterlinearExport);
+			string[] wss;
+			if (IsNullOrEmpty(Settings.Default.FreeTranslationWsForFWInterlinearExport))
+			{
+				var analysisCode = Program.CurrentProject.AnalysisISO3CodeAndName?.Split(':')[0];
+				wss = analysisCode != null ? new[] { analysisCode, "en" } : new[] { "en" };
+			}
+			else
+			{
+				wss = new[] { Settings.Default.FreeTranslationWsForFWInterlinearExport, "en" };
+			}
+
+			InitializeWritingSystemCombo(_comboTranslationWs, wss);
 
 			HandleWritingSystemChanged(null, null);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		private void _comboTranslationWs_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			FormatImportInstructions();
 		}
 	}
 }

--- a/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.resx
+++ b/src/SayMore/Transcription/UI/ExportToFieldWorksInterlinearDlg.resx
@@ -112,12 +112,15 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="locExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="locExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="locExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
Though not a "fix" for SP-2378, that issue inspired this improvement. Made a small tweak to the logic to select the correct writing system for translations when the user has set the analysis WS in SayMore. Also made some internationalization/localization improvements in this area of the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/236)
<!-- Reviewable:end -->
