### PR TITLE
SP-2388:  Fixed hang in text annotations

### DIFF
--- a/build/SayMore.proj
+++ b/build/SayMore.proj
@@ -86,7 +86,7 @@
 	</ItemGroup>
 	<NUnit3 Condition="'$(teamcity_version)' == ''"
 		Assemblies="@(TestAssemblies)"
-		ToolPath="$(RootDir)/packages/NUnit.ConsoleRunner.3.20.0/tools"
+		ToolPath="$(RootDir)/packages/NUnit.ConsoleRunner.3.20.1/tools"
 		ExcludeCategory="$(excludedCategories)"
 		WorkingDirectory="$(RootDir)/output/$(Configuration)"
 		Force32Bit="$(useNUnit-x86)"
@@ -96,7 +96,7 @@
 		TeamCity="false"/>
 	<NUnit3 Condition="'$(teamcity_version)' != ''"
 		Assemblies="@(TestAssemblies)"
-		ToolPath="$(RootDir)/packages/NUnit.ConsoleRunner.3.20.0/tools"
+		ToolPath="$(RootDir)/packages/NUnit.ConsoleRunner.3.20.1/tools"
 		ExcludeCategory="SkipOnTeamCity,$(excludedCategories)"
 		WorkingDirectory="$(RootDir)/output/$(Configuration)"
 		Force32Bit="$(useNUnit-x86)"

--- a/src/SayMoreTests/UI/Charts/ChartBarInfoTests.cs
+++ b/src/SayMoreTests/UI/Charts/ChartBarInfoTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using L10NSharp;
 using NUnit.Framework;
 using Moq;
 using SayMore.Model;
@@ -21,6 +22,8 @@ namespace SayMoreTests.UI.Charts
 		[SetUp]
 		public void TestSetup()
 		{
+			LocalizationManager.StrictInitializationMode = false;
+
 			_sessions = new List<Session>();
 
 			var session = new Mock<Session>();

--- a/src/SayMoreTests/UI/ComponentEditors/EditorBaseTests.cs
+++ b/src/SayMoreTests/UI/ComponentEditors/EditorBaseTests.cs
@@ -120,9 +120,13 @@ namespace SayMoreTests.UI.ComponentEditors
 		}
 
 		/// ------------------------------------------------------------------------------------
-		[Test][Category("SkipOnTeamCity")] // REVIEW: Don't understand why this no longer passes on TC. Passes consistently on developer computer.
+		[Test]
+		[Category("SkipOnTeamCity")]
 		public void OnFormLostFocus_FocusMovedOutsideForm_MethodCalled()
 		{
+			if (!Environment.UserInteractive)
+				Assert.Ignore("Ignored in CI");
+			
 			var otherForm = new TestForm();
 			_testForm.Activate();
 

--- a/src/SayMoreTests/UI/ComponentEditors/EditorBaseTests.cs
+++ b/src/SayMoreTests/UI/ComponentEditors/EditorBaseTests.cs
@@ -32,7 +32,7 @@ namespace SayMoreTests.UI.ComponentEditors
 
 			protected override void OnEditorAndChildrenLostFocus()
 			{
-				EditorAndChildrenLostFocus(this, null);
+				EditorAndChildrenLostFocus?.Invoke(this, null);
 			}
 
 			protected override void OnFormLostFocus()
@@ -56,6 +56,9 @@ namespace SayMoreTests.UI.ComponentEditors
 		[SetUp]
 		public void Setup()
 		{
+			if (!Environment.UserInteractive)
+				Assert.Ignore("Ignored in CI");
+			
 			_editor = new TestEditor();
 			_testForm = new TestForm();
 			_testForm.Controls.Add(_editor);
@@ -72,27 +75,22 @@ namespace SayMoreTests.UI.ComponentEditors
 			_panelInEditorInner.Controls.AddRange(new Control[] { _labelInEditor, _buttonInEditor });
 			_panelInEditorOuter.Controls.AddRange(new Control[] { _panelInEditorInner, _textBoxInEditor });
 			_editor.Controls.Add(_panelInEditorOuter);
+
+			Assert.That(_editor.ChildControls, Is.EquivalentTo(new Control[]
+			{
+				_panelInEditorOuter,
+				_panelInEditorInner,
+				_labelInEditor,
+				_buttonInEditor,
+				_textBoxInEditor
+			}));
 		}
 
 		/// ------------------------------------------------------------------------------------
 		[TearDown]
 		public void TearDown()
 		{
-			_testForm.Dispose();
-		}
-
-		/// ------------------------------------------------------------------------------------
-		[Test]
-		public void ChildControls_VerifyAllControlsInList()
-		{
-			Assert.That(_editor.ChildControls, Is.EquivalentTo(new Control[] 
-				{
-					_panelInEditorOuter,
-					_panelInEditorInner,
-					_labelInEditor, 
-					_buttonInEditor,
-					_textBoxInEditor
-				}));
+			_testForm?.Dispose();
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -121,12 +119,8 @@ namespace SayMoreTests.UI.ComponentEditors
 
 		/// ------------------------------------------------------------------------------------
 		[Test]
-		[Category("SkipOnTeamCity")]
 		public void OnFormLostFocus_FocusMovedOutsideForm_MethodCalled()
 		{
-			if (!Environment.UserInteractive)
-				Assert.Ignore("Ignored in CI");
-			
 			var otherForm = new TestForm();
 			_testForm.Activate();
 

--- a/src/SayMoreTests/UI/ProjectWindow/ReleaseNotesCommandTests.cs
+++ b/src/SayMoreTests/UI/ProjectWindow/ReleaseNotesCommandTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Extensions.Forms;
 using NUnit.Framework;
 using SayMore.UI.ProjectWindow;
@@ -12,6 +13,9 @@ namespace SayMoreTests.UI.ProjectWindow
 		[NonParallelizable]
 		public void Execute_LaunchAndClose_DoesNotCrash()
 		{
+			if (!Environment.UserInteractive)
+				Assert.Ignore("Ignored in CI");
+			
 			var tester = new ModalFormTester();
 			var buttonTester = new ButtonTester("_okButton");
 			tester.ExpectModal("ShowReleaseNotesDialog", () => buttonTester.FireEvent("Click"));

--- a/src/SayMoreTests/packages.config
+++ b/src/SayMoreTests/packages.config
@@ -28,7 +28,7 @@
   <package id="NDesk.DBus" version="0.15.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
   <package id="NUnit" version="3.14.0" targetFramework="net462" />
-  <package id="NUnit.ConsoleRunner" version="3.20.0" targetFramework="net462" />
+  <package id="NUnit.ConsoleRunner" version="3.20.1" targetFramework="net462" />
   <package id="NUnit3TestAdapter" version="4.6.0" targetFramework="net462" developmentDependency="true" />
   <package id="PangoSharp-signed" version="3.22.24.37" targetFramework="net462" />
   <package id="SIL.Archiving" version="16.1.0" targetFramework="net462" />


### PR DESCRIPTION
Bug: If you click in the last row of the annotations grid and then quickly press mouse down before the playback starts, SayMore will think it needs to wait until the playback ends and will appear to hang until it has waited for the entire duration of the audio file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/saymore/239)
<!-- Reviewable:end -->
